### PR TITLE
Ignore Versoix VD in dataset

### DIFF
--- a/src/data/cities.json
+++ b/src/data/cities.json
@@ -23605,11 +23605,6 @@
         "canton": "VD"
     },
     {
-        "city": "Versoix",
-        "zipcode": 1290,
-        "canton": "VD"
-    },
-    {
         "city": "Mies",
         "zipcode": 1295,
         "canton": "VD"


### PR DESCRIPTION
My commit https://github.com/stefanzweifel/php-swiss-cantons/commit/7124f060aa4b21e6e38f17468530a34704c06b5d in #47 broke the test suite.

This PR "fixes" (with big air quotes), by removing the "Versoix VD" data from the dataset.
I couldn't find a source that would confirm that "Versoix" is a city in Vaudt.[^1] 


[^1]: [Wikipedia](https://en.wikipedia.org/wiki/Versoix) as well mentions that the city is part of Geneva