### PR TITLE
Add NotUniqueCantonException

### DIFF
--- a/src/CantonManager.php
+++ b/src/CantonManager.php
@@ -3,6 +3,7 @@
 namespace Wnx\SwissCantons;
 
 use Wnx\SwissCantons\Exceptions\CantonNotFoundException;
+use Wnx\SwissCantons\Exceptions\NotUniqueCantonException;
 
 class CantonManager
 {
@@ -81,29 +82,30 @@ class CantonManager
      * @param int $zipcode
      * @param ?string $cityName
      * @return Canton
-     * @throws CantonNotFoundException
+     * @throws CantonNotFoundException|NotUniqueCantonException
      */
     public function getByZipcodeAndCity(int $zipcode, ?string $cityName = null): Canton
     {
-        $cities = $this->citySearch->findByZipcode($zipcode);
+        $cantons = $this->getByZipcode($zipcode);
 
-        if (1 === count($cities)) {
-            return $this->search->findByAbbreviation($cities[0]['canton'])
-                ?? throw CantonNotFoundException::notFoundForZipcode($zipcode);
+        if (1 === count($cantons)) {
+            return $cantons[0];
         }
 
         if (null !== $cityName) {
+            $cities = $this->citySearch->findByZipcode($zipcode);
+
             foreach ($cities as $city) {
                 if ($city['city'] === $cityName) {
                     return $this->search->findByAbbreviation($city['canton'])
-                        ?? throw CantonNotFoundException::notFoundForZipcodeAndCity($zipcode, $cityName);
+                        ?? throw CantonNotFoundException::notFoundForAbbreviation($city['canton']);
                 }
             }
 
-            throw CantonNotFoundException::notFoundForZipcodeAndCity($zipcode, $cityName);
+            throw NotUniqueCantonException::notUniqueForZipcodeAndCity($zipcode, $cityName);
         }
 
-        throw CantonNotFoundException::notFoundForZipcode($zipcode);
+        throw NotUniqueCantonException::notUniqueForZipcode($zipcode);
     }
 
 }

--- a/src/Exceptions/CantonNotFoundException.php
+++ b/src/Exceptions/CantonNotFoundException.php
@@ -23,10 +23,4 @@ class CantonNotFoundException extends Exception
         /** @phpstan-ignore-next-line */
         return new static("Couldn't find Canton for given zipcode: {$zipcode}");
     }
-
-    public static function notFoundForZipcodeAndCity(int $zipcode, string $city): self
-    {
-        /** @phpstan-ignore-next-line */
-        return new static("Couldn't find Canton for given zipcode and city name: {$zipcode}, {$city}");
-    }
 }

--- a/src/Exceptions/NotUniqueCantonException.php
+++ b/src/Exceptions/NotUniqueCantonException.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Wnx\SwissCantons\Exceptions;
+
+use Exception;
+
+class NotUniqueCantonException extends Exception
+{
+    public static function notUniqueForZipcode(int $zipcode): self
+    {
+        /** @phpstan-ignore-next-line */
+        return new static("Couldn't find an unique Canton for given zipcode: {$zipcode}");
+    }
+
+    public static function notUniqueForZipcodeAndCity(int $zipcode, string $city): self
+    {
+        /** @phpstan-ignore-next-line */
+        return new static("Couldn't find an unique Canton for given zipcode and city name: {$zipcode}, {$city}");
+    }
+}

--- a/tests/CantonManagerTest.php
+++ b/tests/CantonManagerTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Wnx\SwissCantons\Canton;
 use Wnx\SwissCantons\CantonManager;
 use Wnx\SwissCantons\Exceptions\CantonNotFoundException;
+use Wnx\SwissCantons\Exceptions\NotUniqueCantonException;
 
 class CantonManagerTest extends TestCase
 {
@@ -132,13 +133,23 @@ class CantonManagerTest extends TestCase
     }
 
     #[Test]
-    public function it_finds_single_canton_with_zipcode(): void
+    public function it_finds_single_canton_with_zipcode_for_one_city(): void
     {
         $cantonManager = new CantonManager();
 
         $canton = $cantonManager->getByZipcodeAndCity(1003);
 
         $this->assertEquals('VD', $canton->getAbbreviation());
+    }
+
+    #[Test]
+    public function it_finds_single_canton_with_zipcode_for_several_cities_in_same_canton(): void
+    {
+        $cantonManager = new CantonManager();
+
+        $canton = $cantonManager->getByZipcodeAndCity(8914);
+
+        $this->assertEquals('ZH', $canton->getAbbreviation());
     }
 
     #[Test]
@@ -154,10 +165,20 @@ class CantonManagerTest extends TestCase
     #[Test]
     public function it_throws_exception_if_no_canton_for_zipcode_and_city_could_be_found(): void
     {
-        $this->expectException(CantonNotFoundException::class);
+        $this->expectException(NotUniqueCantonException::class);
 
         $canton = new CantonManager();
 
         $canton->getByZipcodeAndCity(1290, 'Lausanne');
+    }
+
+    #[Test]
+    public function it_throws_exception_if_no_unique_canton_for_zipcode(): void
+    {
+        $this->expectException(NotUniqueCantonException::class);
+
+        $canton = new CantonManager();
+
+        $canton->getByZipcodeAndCity(1290);
     }
 }


### PR DESCRIPTION
When using the new feature for my project, I realized I missed a case.

When a zipcode is linked to several cities in the same canton, we can return this canton without testing the city name.
Research by city name is only running when cities for a zipcode are from different cantons