### PR TITLE
Fix cities.json generation - Remove canton from cities' names

### DIFF
--- a/src/data/cities.json
+++ b/src/data/cities.json
@@ -120,7 +120,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Benken ZH",
+        "city": "Benken",
         "zipcode": 8463,
         "canton": "ZH"
     },
@@ -320,7 +320,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Teufen ZH",
+        "city": "Teufen",
         "zipcode": 8428,
         "canton": "ZH"
     },
@@ -415,7 +415,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Teufen ZH",
+        "city": "Teufen",
         "zipcode": 8428,
         "canton": "ZH"
     },
@@ -430,12 +430,12 @@
         "canton": "ZH"
     },
     {
-        "city": "Wil ZH",
+        "city": "Wil",
         "zipcode": 8196,
         "canton": "ZH"
     },
     {
-        "city": "Wil ZH",
+        "city": "Wil",
         "zipcode": 8196,
         "canton": "ZH"
     },
@@ -470,7 +470,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Buchs ZH",
+        "city": "Buchs",
         "zipcode": 8107,
         "canton": "ZH"
     },
@@ -480,7 +480,7 @@
         "canton": "ZH"
     },
     {
-        "city": "D\u00e4nikon ZH",
+        "city": "D\u00e4nikon",
         "zipcode": 8114,
         "canton": "ZH"
     },
@@ -520,7 +520,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Niederglatt ZH",
+        "city": "Niederglatt",
         "zipcode": 8172,
         "canton": "ZH"
     },
@@ -545,7 +545,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Oberglatt ZH",
+        "city": "Oberglatt",
         "zipcode": 8154,
         "canton": "ZH"
     },
@@ -560,7 +560,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Buchs ZH",
+        "city": "Buchs",
         "zipcode": 8107,
         "canton": "ZH"
     },
@@ -685,7 +685,7 @@
         "canton": "ZH"
     },
     {
-        "city": "R\u00fcti ZH",
+        "city": "R\u00fcti",
         "zipcode": 8630,
         "canton": "ZH"
     },
@@ -700,7 +700,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Wald ZH",
+        "city": "Wald",
         "zipcode": 8636,
         "canton": "ZH"
     },
@@ -745,7 +745,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Gossau ZH",
+        "city": "Gossau",
         "zipcode": 8625,
         "canton": "ZH"
     },
@@ -780,12 +780,12 @@
         "canton": "ZH"
     },
     {
-        "city": "R\u00fcti ZH",
+        "city": "R\u00fcti",
         "zipcode": 8630,
         "canton": "ZH"
     },
     {
-        "city": "Wald ZH",
+        "city": "Wald",
         "zipcode": 8636,
         "canton": "ZH"
     },
@@ -800,12 +800,12 @@
         "canton": "ZH"
     },
     {
-        "city": "Wald ZH",
+        "city": "Wald",
         "zipcode": 8636,
         "canton": "ZH"
     },
     {
-        "city": "Laupen ZH",
+        "city": "Laupen",
         "zipcode": 8637,
         "canton": "ZH"
     },
@@ -815,12 +815,12 @@
         "canton": "ZH"
     },
     {
-        "city": "Wetzikon ZH",
+        "city": "Wetzikon",
         "zipcode": 8620,
         "canton": "ZH"
     },
     {
-        "city": "Wetzikon ZH",
+        "city": "Wetzikon",
         "zipcode": 8623,
         "canton": "ZH"
     },
@@ -835,7 +835,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Kilchberg ZH",
+        "city": "Kilchberg",
         "zipcode": 8802,
         "canton": "ZH"
     },
@@ -880,12 +880,12 @@
         "canton": "ZH"
     },
     {
-        "city": "Erlenbach ZH",
+        "city": "Erlenbach",
         "zipcode": 8703,
         "canton": "ZH"
     },
     {
-        "city": "Erlenbach ZH",
+        "city": "Erlenbach",
         "zipcode": 8703,
         "canton": "ZH"
     },
@@ -915,7 +915,7 @@
         "canton": "ZH"
     },
     {
-        "city": "K\u00fcsnacht ZH",
+        "city": "K\u00fcsnacht",
         "zipcode": 8700,
         "canton": "ZH"
     },
@@ -1000,7 +1000,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Winterberg ZH",
+        "city": "Winterberg",
         "zipcode": 8312,
         "canton": "ZH"
     },
@@ -1015,7 +1015,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Pf\u00e4ffikon ZH",
+        "city": "Pf\u00e4ffikon",
         "zipcode": 8330,
         "canton": "ZH"
     },
@@ -1025,7 +1025,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Wetzikon ZH",
+        "city": "Wetzikon",
         "zipcode": 8623,
         "canton": "ZH"
     },
@@ -1340,7 +1340,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Hagenbuch ZH",
+        "city": "Hagenbuch",
         "zipcode": 8523,
         "canton": "ZH"
     },
@@ -1375,7 +1375,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Rickenbach ZH",
+        "city": "Rickenbach",
         "zipcode": 8545,
         "canton": "ZH"
     },
@@ -1385,7 +1385,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Hofstetten ZH",
+        "city": "Hofstetten",
         "zipcode": 8354,
         "canton": "ZH"
     },
@@ -1395,7 +1395,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Schlatt ZH",
+        "city": "Schlatt",
         "zipcode": 8418,
         "canton": "ZH"
     },
@@ -1500,7 +1500,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Zell ZH",
+        "city": "Zell",
         "zipcode": 8487,
         "canton": "ZH"
     },
@@ -1510,7 +1510,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Aesch ZH",
+        "city": "Aesch",
         "zipcode": 8904,
         "canton": "ZH"
     },
@@ -1520,7 +1520,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Birmensdorf ZH",
+        "city": "Birmensdorf",
         "zipcode": 8903,
         "canton": "ZH"
     },
@@ -1585,7 +1585,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Weiningen ZH",
+        "city": "Weiningen",
         "zipcode": 8104,
         "canton": "ZH"
     },
@@ -1785,7 +1785,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Au ZH",
+        "city": "Au",
         "zipcode": 8804,
         "canton": "ZH"
     },
@@ -1795,7 +1795,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Sch\u00f6nenberg ZH",
+        "city": "Sch\u00f6nenberg",
         "zipcode": 8824,
         "canton": "ZH"
     },
@@ -1810,7 +1810,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Hofstetten ZH",
+        "city": "Hofstetten",
         "zipcode": 8354,
         "canton": "ZH"
     },
@@ -1825,7 +1825,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Hagenbuch ZH",
+        "city": "Hagenbuch",
         "zipcode": 8523,
         "canton": "ZH"
     },
@@ -1930,7 +1930,7 @@
         "canton": "ZH"
     },
     {
-        "city": "Kefikon ZH",
+        "city": "Kefikon",
         "zipcode": 8543,
         "canton": "ZH"
     },
@@ -1950,7 +1950,7 @@
         "canton": "BE"
     },
     {
-        "city": "Seedorf BE",
+        "city": "Seedorf",
         "zipcode": 3267,
         "canton": "BE"
     },
@@ -1965,7 +1965,7 @@
         "canton": "BE"
     },
     {
-        "city": "Bargen BE",
+        "city": "Bargen",
         "zipcode": 3282,
         "canton": "BE"
     },
@@ -1980,7 +1980,7 @@
         "canton": "BE"
     },
     {
-        "city": "Ammerzwil BE",
+        "city": "Ammerzwil",
         "zipcode": 3257,
         "canton": "BE"
     },
@@ -2025,7 +2025,7 @@
         "canton": "BE"
     },
     {
-        "city": "Studen BE",
+        "city": "Studen",
         "zipcode": 2557,
         "canton": "BE"
     },
@@ -2035,7 +2035,7 @@
         "canton": "BE"
     },
     {
-        "city": "Busswil BE",
+        "city": "Busswil",
         "zipcode": 3292,
         "canton": "BE"
     },
@@ -2085,7 +2085,7 @@
         "canton": "BE"
     },
     {
-        "city": "Rapperswil BE",
+        "city": "Rapperswil",
         "zipcode": 3255,
         "canton": "BE"
     },
@@ -2125,7 +2125,7 @@
         "canton": "BE"
     },
     {
-        "city": "Seedorf BE",
+        "city": "Seedorf",
         "zipcode": 3267,
         "canton": "BE"
     },
@@ -2260,7 +2260,7 @@
         "canton": "BE"
     },
     {
-        "city": "Roggwil BE",
+        "city": "Roggwil",
         "zipcode": 4914,
         "canton": "BE"
     },
@@ -2305,7 +2305,7 @@
         "canton": "BE"
     },
     {
-        "city": "Walterswil BE",
+        "city": "Walterswil",
         "zipcode": 4942,
         "canton": "BE"
     },
@@ -2750,7 +2750,7 @@
         "canton": "BE"
     },
     {
-        "city": "Studen BE",
+        "city": "Studen",
         "zipcode": 2557,
         "canton": "BE"
     },
@@ -2780,7 +2780,7 @@
         "canton": "BE"
     },
     {
-        "city": "Lengnau BE",
+        "city": "Lengnau",
         "zipcode": 2543,
         "canton": "BE"
     },
@@ -2835,7 +2835,7 @@
         "canton": "BE"
     },
     {
-        "city": "B\u00e4riswil BE",
+        "city": "B\u00e4riswil",
         "zipcode": 3323,
         "canton": "BE"
     },
@@ -2860,7 +2860,7 @@
         "canton": "BE"
     },
     {
-        "city": "Kirchberg BE",
+        "city": "Kirchberg",
         "zipcode": 3422,
         "canton": "BE"
     },
@@ -2990,7 +2990,7 @@
         "canton": "BE"
     },
     {
-        "city": "Kirchberg BE",
+        "city": "Kirchberg",
         "zipcode": 3422,
         "canton": "BE"
     },
@@ -3190,7 +3190,7 @@
         "canton": "BE"
     },
     {
-        "city": "Renan BE",
+        "city": "Renan",
         "zipcode": 2616,
         "canton": "BE"
     },
@@ -3205,7 +3205,7 @@
         "canton": "BE"
     },
     {
-        "city": "Romont BE",
+        "city": "Romont",
         "zipcode": 2538,
         "canton": "BE"
     },
@@ -3425,7 +3425,7 @@
         "canton": "BE"
     },
     {
-        "city": "Siselen BE",
+        "city": "Siselen",
         "zipcode": 2577,
         "canton": "BE"
     },
@@ -3615,7 +3615,7 @@
         "canton": "BE"
     },
     {
-        "city": "Zuzwil BE",
+        "city": "Zuzwil",
         "zipcode": 3303,
         "canton": "BE"
     },
@@ -3760,7 +3760,7 @@
         "canton": "BE"
     },
     {
-        "city": "Brienz BE",
+        "city": "Brienz",
         "zipcode": 3855,
         "canton": "BE"
     },
@@ -3935,7 +3935,7 @@
         "canton": "BE"
     },
     {
-        "city": "Brienz BE",
+        "city": "Brienz",
         "zipcode": 3855,
         "canton": "BE"
     },
@@ -3945,7 +3945,7 @@
         "canton": "BE"
     },
     {
-        "city": "Ringgenberg BE",
+        "city": "Ringgenberg",
         "zipcode": 3852,
         "canton": "BE"
     },
@@ -3975,7 +3975,7 @@
         "canton": "BE"
     },
     {
-        "city": "Arni BE",
+        "city": "Arni",
         "zipcode": 3508,
         "canton": "BE"
     },
@@ -4070,7 +4070,7 @@
         "canton": "BE"
     },
     {
-        "city": "Arni BE",
+        "city": "Arni",
         "zipcode": 3508,
         "canton": "BE"
     },
@@ -4145,7 +4145,7 @@
         "canton": "BE"
     },
     {
-        "city": "Arni BE",
+        "city": "Arni",
         "zipcode": 3508,
         "canton": "BE"
     },
@@ -4195,7 +4195,7 @@
         "canton": "BE"
     },
     {
-        "city": "R\u00fcfenacht BE",
+        "city": "R\u00fcfenacht",
         "zipcode": 3075,
         "canton": "BE"
     },
@@ -4295,7 +4295,7 @@
         "canton": "BE"
     },
     {
-        "city": "Laupen BE",
+        "city": "Laupen",
         "zipcode": 3177,
         "canton": "BE"
     },
@@ -4360,7 +4360,7 @@
         "canton": "BE"
     },
     {
-        "city": "Laupen BE",
+        "city": "Laupen",
         "zipcode": 3177,
         "canton": "BE"
     },
@@ -4400,7 +4400,7 @@
         "canton": "BE"
     },
     {
-        "city": "Laupen BE",
+        "city": "Laupen",
         "zipcode": 3177,
         "canton": "BE"
     },
@@ -4425,7 +4425,7 @@
         "canton": "BE"
     },
     {
-        "city": "Corcelles BE",
+        "city": "Corcelles",
         "zipcode": 2747,
         "canton": "BE"
     },
@@ -4495,7 +4495,7 @@
         "canton": "BE"
     },
     {
-        "city": "Roches BE",
+        "city": "Roches",
         "zipcode": 2762,
         "canton": "BE"
     },
@@ -4520,7 +4520,7 @@
         "canton": "BE"
     },
     {
-        "city": "Saules BE",
+        "city": "Saules",
         "zipcode": 2732,
         "canton": "BE"
     },
@@ -4685,7 +4685,7 @@
         "canton": "BE"
     },
     {
-        "city": "Br\u00fcgg BE",
+        "city": "Br\u00fcgg",
         "zipcode": 2555,
         "canton": "BE"
     },
@@ -4790,7 +4790,7 @@
         "canton": "BE"
     },
     {
-        "city": "Studen BE",
+        "city": "Studen",
         "zipcode": 2557,
         "canton": "BE"
     },
@@ -5020,7 +5020,7 @@
         "canton": "BE"
     },
     {
-        "city": "Unterbach BE",
+        "city": "Unterbach",
         "zipcode": 3857,
         "canton": "BE"
     },
@@ -5325,17 +5325,17 @@
         "canton": "BE"
     },
     {
-        "city": "Kirchdorf BE",
+        "city": "Kirchdorf",
         "zipcode": 3116,
         "canton": "BE"
     },
     {
-        "city": "M\u00fchledorf BE",
+        "city": "M\u00fchledorf",
         "zipcode": 3116,
         "canton": "BE"
     },
     {
-        "city": "Noflen BE",
+        "city": "Noflen",
         "zipcode": 3116,
         "canton": "BE"
     },
@@ -5815,7 +5815,7 @@
         "canton": "BE"
     },
     {
-        "city": "Buchen BE",
+        "city": "Buchen",
         "zipcode": 3623,
         "canton": "BE"
     },
@@ -6080,7 +6080,7 @@
         "canton": "BE"
     },
     {
-        "city": "Walterswil BE",
+        "city": "Walterswil",
         "zipcode": 4942,
         "canton": "BE"
     },
@@ -6270,7 +6270,7 @@
         "canton": "BE"
     },
     {
-        "city": "Walterswil BE",
+        "city": "Walterswil",
         "zipcode": 4942,
         "canton": "BE"
     },
@@ -6500,7 +6500,7 @@
         "canton": "LU"
     },
     {
-        "city": "Schachen LU",
+        "city": "Schachen",
         "zipcode": 6105,
         "canton": "LU"
     },
@@ -6530,7 +6530,7 @@
         "canton": "LU"
     },
     {
-        "city": "Hasle LU",
+        "city": "Hasle",
         "zipcode": 6166,
         "canton": "LU"
     },
@@ -6545,7 +6545,7 @@
         "canton": "LU"
     },
     {
-        "city": "Fl\u00fchli LU",
+        "city": "Fl\u00fchli",
         "zipcode": 6173,
         "canton": "LU"
     },
@@ -6575,7 +6575,7 @@
         "canton": "LU"
     },
     {
-        "city": "Hasle LU",
+        "city": "Hasle",
         "zipcode": 6166,
         "canton": "LU"
     },
@@ -6595,7 +6595,7 @@
         "canton": "LU"
     },
     {
-        "city": "Hasle LU",
+        "city": "Hasle",
         "zipcode": 6166,
         "canton": "LU"
     },
@@ -6615,7 +6615,7 @@
         "canton": "LU"
     },
     {
-        "city": "Schachen LU",
+        "city": "Schachen",
         "zipcode": 6105,
         "canton": "LU"
     },
@@ -6640,7 +6640,7 @@
         "canton": "LU"
     },
     {
-        "city": "Fl\u00fchli LU",
+        "city": "Fl\u00fchli",
         "zipcode": 6173,
         "canton": "LU"
     },
@@ -6655,7 +6655,7 @@
         "canton": "LU"
     },
     {
-        "city": "Marbach LU",
+        "city": "Marbach",
         "zipcode": 6196,
         "canton": "LU"
     },
@@ -6665,7 +6665,7 @@
         "canton": "LU"
     },
     {
-        "city": "Aesch LU",
+        "city": "Aesch",
         "zipcode": 6287,
         "canton": "LU"
     },
@@ -6675,7 +6675,7 @@
         "canton": "LU"
     },
     {
-        "city": "Eschenbach LU",
+        "city": "Eschenbach",
         "zipcode": 6274,
         "canton": "LU"
     },
@@ -6720,7 +6720,7 @@
         "canton": "LU"
     },
     {
-        "city": "Eschenbach LU",
+        "city": "Eschenbach",
         "zipcode": 6274,
         "canton": "LU"
     },
@@ -6730,7 +6730,7 @@
         "canton": "LU"
     },
     {
-        "city": "Sulz LU",
+        "city": "Sulz",
         "zipcode": 6284,
         "canton": "LU"
     },
@@ -6775,7 +6775,7 @@
         "canton": "LU"
     },
     {
-        "city": "Eschenbach LU",
+        "city": "Eschenbach",
         "zipcode": 6274,
         "canton": "LU"
     },
@@ -6815,7 +6815,7 @@
         "canton": "LU"
     },
     {
-        "city": "Lieli LU",
+        "city": "Lieli",
         "zipcode": 6277,
         "canton": "LU"
     },
@@ -6850,7 +6850,7 @@
         "canton": "LU"
     },
     {
-        "city": "R\u00f6merswil LU",
+        "city": "R\u00f6merswil",
         "zipcode": 6027,
         "canton": "LU"
     },
@@ -6890,7 +6890,7 @@
         "canton": "LU"
     },
     {
-        "city": "Aesch LU",
+        "city": "Aesch",
         "zipcode": 6287,
         "canton": "LU"
     },
@@ -6990,7 +6990,7 @@
         "canton": "LU"
     },
     {
-        "city": "St. Niklausen LU",
+        "city": "St. Niklausen",
         "zipcode": 6005,
         "canton": "LU"
     },
@@ -7005,7 +7005,7 @@
         "canton": "LU"
     },
     {
-        "city": "Hergiswil NW",
+        "city": "Hergiswil",
         "zipcode": 6052,
         "canton": "LU"
     },
@@ -7145,7 +7145,7 @@
         "canton": "LU"
     },
     {
-        "city": "Schwarzenberg LU",
+        "city": "Schwarzenberg",
         "zipcode": 6103,
         "canton": "LU"
     },
@@ -7195,12 +7195,12 @@
         "canton": "LU"
     },
     {
-        "city": "Schwarzenbach LU",
+        "city": "Schwarzenbach",
         "zipcode": 6215,
         "canton": "LU"
     },
     {
-        "city": "Rickenbach LU",
+        "city": "Rickenbach",
         "zipcode": 6221,
         "canton": "LU"
     },
@@ -7330,7 +7330,7 @@
         "canton": "LU"
     },
     {
-        "city": "Oberkirch LU",
+        "city": "Oberkirch",
         "zipcode": 6208,
         "canton": "LU"
     },
@@ -7345,12 +7345,12 @@
         "canton": "LU"
     },
     {
-        "city": "Pfeffikon LU",
+        "city": "Pfeffikon",
         "zipcode": 5735,
         "canton": "LU"
     },
     {
-        "city": "Rickenbach LU",
+        "city": "Rickenbach",
         "zipcode": 6221,
         "canton": "LU"
     },
@@ -7375,7 +7375,7 @@
         "canton": "LU"
     },
     {
-        "city": "Schachen LU",
+        "city": "Schachen",
         "zipcode": 6105,
         "canton": "LU"
     },
@@ -7485,7 +7485,7 @@
         "canton": "LU"
     },
     {
-        "city": "Zell LU",
+        "city": "Zell",
         "zipcode": 6144,
         "canton": "LU"
     },
@@ -7515,7 +7515,7 @@
         "canton": "LU"
     },
     {
-        "city": "Buchs LU",
+        "city": "Buchs",
         "zipcode": 6211,
         "canton": "LU"
     },
@@ -7575,7 +7575,7 @@
         "canton": "LU"
     },
     {
-        "city": "Fischbach LU",
+        "city": "Fischbach",
         "zipcode": 6145,
         "canton": "LU"
     },
@@ -7590,6 +7590,11 @@
         "canton": "LU"
     },
     {
+        "city": "Fischbach",
+        "zipcode": 6145,
+        "canton": "LU"
+    },
+    {
         "city": "Grossdietwil",
         "zipcode": 6146,
         "canton": "LU"
@@ -7597,6 +7602,11 @@
     {
         "city": "Altb\u00fcron",
         "zipcode": 6147,
+        "canton": "LU"
+    },
+    {
+        "city": "Ebersecken",
+        "zipcode": 6245,
         "canton": "LU"
     },
     {
@@ -7785,7 +7795,7 @@
         "canton": "LU"
     },
     {
-        "city": "Zell LU",
+        "city": "Zell",
         "zipcode": 6144,
         "canton": "LU"
     },
@@ -7840,7 +7850,7 @@
         "canton": "LU"
     },
     {
-        "city": "Zell LU",
+        "city": "Zell",
         "zipcode": 6144,
         "canton": "LU"
     },
@@ -7860,7 +7870,7 @@
         "canton": "LU"
     },
     {
-        "city": "Altdorf UR",
+        "city": "Altdorf",
         "zipcode": 6460,
         "canton": "UR"
     },
@@ -7890,12 +7900,12 @@
         "canton": "UR"
     },
     {
-        "city": "Altdorf UR",
+        "city": "Altdorf",
         "zipcode": 6460,
         "canton": "UR"
     },
     {
-        "city": "B\u00fcrglen UR",
+        "city": "B\u00fcrglen",
         "zipcode": 6463,
         "canton": "UR"
     },
@@ -7917,6 +7927,11 @@
     {
         "city": "Fl\u00fcelen",
         "zipcode": 6454,
+        "canton": "UR"
+    },
+    {
+        "city": "Altdorf",
+        "zipcode": 6460,
         "canton": "UR"
     },
     {
@@ -7970,7 +7985,7 @@
         "canton": "UR"
     },
     {
-        "city": "Seedorf UR",
+        "city": "Seedorf",
         "zipcode": 6462,
         "canton": "UR"
     },
@@ -8045,7 +8060,7 @@
         "canton": "UR"
     },
     {
-        "city": "Wassen UR",
+        "city": "Wassen",
         "zipcode": 6484,
         "canton": "UR"
     },
@@ -8085,7 +8100,7 @@
         "canton": "SZ"
     },
     {
-        "city": "Egg SZ",
+        "city": "Egg",
         "zipcode": 8847,
         "canton": "SZ"
     },
@@ -8120,7 +8135,7 @@
         "canton": "SZ"
     },
     {
-        "city": "Egg SZ",
+        "city": "Egg",
         "zipcode": 8847,
         "canton": "SZ"
     },
@@ -8130,7 +8145,7 @@
         "canton": "SZ"
     },
     {
-        "city": "B\u00e4ch SZ",
+        "city": "B\u00e4ch",
         "zipcode": 8806,
         "canton": "SZ"
     },
@@ -8140,7 +8155,7 @@
         "canton": "SZ"
     },
     {
-        "city": "Pf\u00e4ffikon SZ",
+        "city": "Pf\u00e4ffikon",
         "zipcode": 8808,
         "canton": "SZ"
     },
@@ -8155,7 +8170,7 @@
         "canton": "SZ"
     },
     {
-        "city": "B\u00e4ch SZ",
+        "city": "B\u00e4ch",
         "zipcode": 8806,
         "canton": "SZ"
     },
@@ -8200,7 +8215,7 @@
         "canton": "SZ"
     },
     {
-        "city": "Lachen SZ",
+        "city": "Lachen",
         "zipcode": 8853,
         "canton": "SZ"
     },
@@ -8220,7 +8235,7 @@
         "canton": "SZ"
     },
     {
-        "city": "Lachen SZ",
+        "city": "Lachen",
         "zipcode": 8853,
         "canton": "SZ"
     },
@@ -8235,7 +8250,7 @@
         "canton": "SZ"
     },
     {
-        "city": "Wangen SZ",
+        "city": "Wangen",
         "zipcode": 8855,
         "canton": "SZ"
     },
@@ -8245,7 +8260,7 @@
         "canton": "SZ"
     },
     {
-        "city": "Buttikon SZ",
+        "city": "Buttikon",
         "zipcode": 8863,
         "canton": "SZ"
     },
@@ -8255,7 +8270,7 @@
         "canton": "SZ"
     },
     {
-        "city": "Wangen SZ",
+        "city": "Wangen",
         "zipcode": 8855,
         "canton": "SZ"
     },
@@ -8270,7 +8285,7 @@
         "canton": "SZ"
     },
     {
-        "city": "Lachen SZ",
+        "city": "Lachen",
         "zipcode": 8853,
         "canton": "SZ"
     },
@@ -8280,7 +8295,7 @@
         "canton": "SZ"
     },
     {
-        "city": "Wangen SZ",
+        "city": "Wangen",
         "zipcode": 8855,
         "canton": "SZ"
     },
@@ -8340,7 +8355,7 @@
         "canton": "SZ"
     },
     {
-        "city": "Seewen SZ",
+        "city": "Seewen",
         "zipcode": 6423,
         "canton": "SZ"
     },
@@ -8355,7 +8370,7 @@
         "canton": "SZ"
     },
     {
-        "city": "Stoos SZ",
+        "city": "Stoos",
         "zipcode": 6433,
         "canton": "SZ"
     },
@@ -8375,7 +8390,7 @@
         "canton": "SZ"
     },
     {
-        "city": "Stoos SZ",
+        "city": "Stoos",
         "zipcode": 6433,
         "canton": "SZ"
     },
@@ -8445,7 +8460,7 @@
         "canton": "SZ"
     },
     {
-        "city": "Seewen SZ",
+        "city": "Seewen",
         "zipcode": 6423,
         "canton": "SZ"
     },
@@ -8495,7 +8510,7 @@
         "canton": "SZ"
     },
     {
-        "city": "Studen SZ",
+        "city": "Studen",
         "zipcode": 8845,
         "canton": "SZ"
     },
@@ -8545,7 +8560,7 @@
         "canton": "OW"
     },
     {
-        "city": "St. Niklausen OW",
+        "city": "St. Niklausen",
         "zipcode": 6066,
         "canton": "OW"
     },
@@ -8565,7 +8580,7 @@
         "canton": "OW"
     },
     {
-        "city": "B\u00fcrglen OW",
+        "city": "B\u00fcrglen",
         "zipcode": 6078,
         "canton": "OW"
     },
@@ -8690,17 +8705,37 @@
         "canton": "NW"
     },
     {
-        "city": "Hergiswil NW",
+        "city": "Kriens",
+        "zipcode": 6010,
+        "canton": "NW"
+    },
+    {
+        "city": "Eigenthal",
+        "zipcode": 6013,
+        "canton": "NW"
+    },
+    {
+        "city": "Hergiswil",
         "zipcode": 6052,
         "canton": "NW"
     },
     {
-        "city": "Oberdorf NW",
+        "city": "Stans",
         "zipcode": 6370,
         "canton": "NW"
     },
     {
-        "city": "B\u00fcren NW",
+        "city": "Oberdorf",
+        "zipcode": 6370,
+        "canton": "NW"
+    },
+    {
+        "city": "Buochs",
+        "zipcode": 6374,
+        "canton": "NW"
+    },
+    {
+        "city": "B\u00fcren",
         "zipcode": 6382,
         "canton": "NW"
     },
@@ -8741,6 +8776,11 @@
     },
     {
         "city": "F\u00fcrigen",
+        "zipcode": 6363,
+        "canton": "NW"
+    },
+    {
+        "city": "B\u00fcrgenstock",
         "zipcode": 6363,
         "canton": "NW"
     },
@@ -8850,7 +8890,7 @@
         "canton": "GL"
     },
     {
-        "city": "Schwanden GL",
+        "city": "Schwanden",
         "zipcode": 8762,
         "canton": "GL"
     },
@@ -8885,7 +8925,7 @@
         "canton": "GL"
     },
     {
-        "city": "Haslen GL",
+        "city": "Haslen",
         "zipcode": 8773,
         "canton": "GL"
     },
@@ -8905,7 +8945,7 @@
         "canton": "GL"
     },
     {
-        "city": "Diesbach GL",
+        "city": "Diesbach",
         "zipcode": 8777,
         "canton": "GL"
     },
@@ -8915,7 +8955,7 @@
         "canton": "GL"
     },
     {
-        "city": "R\u00fcti GL",
+        "city": "R\u00fcti",
         "zipcode": 8782,
         "canton": "GL"
     },
@@ -9120,7 +9160,7 @@
         "canton": "ZG"
     },
     {
-        "city": "Holzh\u00e4usern ZG",
+        "city": "Holzh\u00e4usern",
         "zipcode": 6343,
         "canton": "ZG"
     },
@@ -9185,12 +9225,12 @@
         "canton": "ZG"
     },
     {
-        "city": "Ch\u00e2tillon FR",
+        "city": "Ch\u00e2tillon",
         "zipcode": 1473,
         "canton": "FR"
     },
     {
-        "city": "Cugy FR",
+        "city": "Cugy",
         "zipcode": 1482,
         "canton": "FR"
     },
@@ -9215,7 +9255,7 @@
         "canton": "FR"
     },
     {
-        "city": "Lully FR",
+        "city": "Lully",
         "zipcode": 1470,
         "canton": "FR"
     },
@@ -9280,7 +9320,7 @@
         "canton": "FR"
     },
     {
-        "city": "St-Aubin FR",
+        "city": "St-Aubin",
         "zipcode": 1566,
         "canton": "FR"
     },
@@ -9300,7 +9340,7 @@
         "canton": "FR"
     },
     {
-        "city": "Villeneuve FR",
+        "city": "Villeneuve",
         "zipcode": 1527,
         "canton": "FR"
     },
@@ -9365,7 +9405,7 @@
         "canton": "FR"
     },
     {
-        "city": "Dompierre FR",
+        "city": "Dompierre",
         "zipcode": 1563,
         "canton": "FR"
     },
@@ -9430,7 +9470,7 @@
         "canton": "FR"
     },
     {
-        "city": "Forel FR",
+        "city": "Forel",
         "zipcode": 1475,
         "canton": "FR"
     },
@@ -9450,12 +9490,12 @@
         "canton": "FR"
     },
     {
-        "city": "Bussy FR",
+        "city": "Bussy",
         "zipcode": 1541,
         "canton": "FR"
     },
     {
-        "city": "Morens FR",
+        "city": "Morens",
         "zipcode": 1541,
         "canton": "FR"
     },
@@ -9470,7 +9510,7 @@
         "canton": "FR"
     },
     {
-        "city": "Ch\u00e2bles FR",
+        "city": "Ch\u00e2bles",
         "zipcode": 1474,
         "canton": "FR"
     },
@@ -9510,7 +9550,7 @@
         "canton": "FR"
     },
     {
-        "city": "Ecublens FR",
+        "city": "Ecublens",
         "zipcode": 1673,
         "canton": "FR"
     },
@@ -9525,7 +9565,7 @@
         "canton": "FR"
     },
     {
-        "city": "Romont FR",
+        "city": "Romont",
         "zipcode": 1680,
         "canton": "FR"
     },
@@ -9535,7 +9575,7 @@
         "canton": "FR"
     },
     {
-        "city": "M\u00e9zi\u00e8res FR",
+        "city": "M\u00e9zi\u00e8res",
         "zipcode": 1684,
         "canton": "FR"
     },
@@ -9545,7 +9585,7 @@
         "canton": "FR"
     },
     {
-        "city": "Romont FR",
+        "city": "Romont",
         "zipcode": 1680,
         "canton": "FR"
     },
@@ -9595,7 +9635,7 @@
         "canton": "FR"
     },
     {
-        "city": "Romont FR",
+        "city": "Romont",
         "zipcode": 1680,
         "canton": "FR"
     },
@@ -9675,7 +9715,7 @@
         "canton": "FR"
     },
     {
-        "city": "La Joux FR",
+        "city": "La Joux",
         "zipcode": 1697,
         "canton": "FR"
     },
@@ -9720,7 +9760,7 @@
         "canton": "FR"
     },
     {
-        "city": "Romont FR",
+        "city": "Romont",
         "zipcode": 1680,
         "canton": "FR"
     },
@@ -9730,7 +9770,7 @@
         "canton": "FR"
     },
     {
-        "city": "Lussy FR",
+        "city": "Lussy",
         "zipcode": 1690,
         "canton": "FR"
     },
@@ -9890,7 +9930,7 @@
         "canton": "FR"
     },
     {
-        "city": "La Roche FR",
+        "city": "La Roche",
         "zipcode": 1634,
         "canton": "FR"
     },
@@ -9970,7 +10010,7 @@
         "canton": "FR"
     },
     {
-        "city": "La Roche FR",
+        "city": "La Roche",
         "zipcode": 1634,
         "canton": "FR"
     },
@@ -10065,7 +10105,7 @@
         "canton": "FR"
     },
     {
-        "city": "Cerniat FR",
+        "city": "Cerniat",
         "zipcode": 1654,
         "canton": "FR"
     },
@@ -10130,7 +10170,7 @@
         "canton": "FR"
     },
     {
-        "city": "Cottens FR",
+        "city": "Cottens",
         "zipcode": 1741,
         "canton": "FR"
     },
@@ -10180,7 +10220,7 @@
         "canton": "FR"
     },
     {
-        "city": "Neyruz FR",
+        "city": "Neyruz",
         "zipcode": 1740,
         "canton": "FR"
     },
@@ -10205,7 +10245,7 @@
         "canton": "FR"
     },
     {
-        "city": "Essert FR",
+        "city": "Essert",
         "zipcode": 1724,
         "canton": "FR"
     },
@@ -10215,7 +10255,7 @@
         "canton": "FR"
     },
     {
-        "city": "Oberried FR",
+        "city": "Oberried",
         "zipcode": 1724,
         "canton": "FR"
     },
@@ -10235,7 +10275,7 @@
         "canton": "FR"
     },
     {
-        "city": "Essert FR",
+        "city": "Essert",
         "zipcode": 1724,
         "canton": "FR"
     },
@@ -10285,7 +10325,7 @@
         "canton": "FR"
     },
     {
-        "city": "Onnens FR",
+        "city": "Onnens",
         "zipcode": 1756,
         "canton": "FR"
     },
@@ -10370,7 +10410,7 @@
         "canton": "FR"
     },
     {
-        "city": "Rossens FR",
+        "city": "Rossens",
         "zipcode": 1728,
         "canton": "FR"
     },
@@ -10405,7 +10445,7 @@
         "canton": "FR"
     },
     {
-        "city": "Ependes FR",
+        "city": "Ependes",
         "zipcode": 1731,
         "canton": "FR"
     },
@@ -10465,7 +10505,7 @@
         "canton": "FR"
     },
     {
-        "city": "Cressier FR",
+        "city": "Cressier",
         "zipcode": 1785,
         "canton": "FR"
     },
@@ -10655,7 +10695,7 @@
         "canton": "FR"
     },
     {
-        "city": "Mur (Vully) FR",
+        "city": "Mur (Vully)",
         "zipcode": 1787,
         "canton": "FR"
     },
@@ -10705,7 +10745,7 @@
         "canton": "FR"
     },
     {
-        "city": "Schmitten FR",
+        "city": "Schmitten",
         "zipcode": 3185,
         "canton": "FR"
     },
@@ -10780,7 +10820,7 @@
         "canton": "FR"
     },
     {
-        "city": "Alterswil FR",
+        "city": "Alterswil",
         "zipcode": 1715,
         "canton": "FR"
     },
@@ -10810,7 +10850,7 @@
         "canton": "FR"
     },
     {
-        "city": "Schmitten FR",
+        "city": "Schmitten",
         "zipcode": 3185,
         "canton": "FR"
     },
@@ -10835,7 +10875,7 @@
         "canton": "FR"
     },
     {
-        "city": "Alterswil FR",
+        "city": "Alterswil",
         "zipcode": 1715,
         "canton": "FR"
     },
@@ -10850,7 +10890,7 @@
         "canton": "FR"
     },
     {
-        "city": "Schmitten FR",
+        "city": "Schmitten",
         "zipcode": 3185,
         "canton": "FR"
     },
@@ -10880,7 +10920,7 @@
         "canton": "FR"
     },
     {
-        "city": "Schmitten FR",
+        "city": "Schmitten",
         "zipcode": 3185,
         "canton": "FR"
     },
@@ -10930,7 +10970,7 @@
         "canton": "FR"
     },
     {
-        "city": "St-Martin FR",
+        "city": "St-Martin",
         "zipcode": 1609,
         "canton": "FR"
     },
@@ -11045,7 +11085,7 @@
         "canton": "SO"
     },
     {
-        "city": "Holderbank SO",
+        "city": "Holderbank",
         "zipcode": 4718,
         "canton": "SO"
     },
@@ -11110,7 +11150,7 @@
         "canton": "SO"
     },
     {
-        "city": "Holderbank SO",
+        "city": "Holderbank",
         "zipcode": 4718,
         "canton": "SO"
     },
@@ -11135,7 +11175,7 @@
         "canton": "SO"
     },
     {
-        "city": "Beinwil SO",
+        "city": "Beinwil",
         "zipcode": 4229,
         "canton": "SO"
     },
@@ -11230,7 +11270,7 @@
         "canton": "SO"
     },
     {
-        "city": "Bibern SO",
+        "city": "Bibern",
         "zipcode": 4578,
         "canton": "SO"
     },
@@ -11250,7 +11290,7 @@
         "canton": "SO"
     },
     {
-        "city": "M\u00fchledorf SO",
+        "city": "M\u00fchledorf",
         "zipcode": 4583,
         "canton": "SO"
     },
@@ -11285,7 +11325,7 @@
         "canton": "SO"
     },
     {
-        "city": "Biel-Benken BL",
+        "city": "Biel-Benken",
         "zipcode": 4105,
         "canton": "SO"
     },
@@ -11295,7 +11335,7 @@
         "canton": "SO"
     },
     {
-        "city": "B\u00fcren SO",
+        "city": "B\u00fcren",
         "zipcode": 4413,
         "canton": "SO"
     },
@@ -11320,7 +11360,7 @@
         "canton": "SO"
     },
     {
-        "city": "Hofstetten SO",
+        "city": "Hofstetten",
         "zipcode": 4114,
         "canton": "SO"
     },
@@ -11360,7 +11400,7 @@
         "canton": "SO"
     },
     {
-        "city": "Seewen SO",
+        "city": "Seewen",
         "zipcode": 4206,
         "canton": "SO"
     },
@@ -11385,7 +11425,7 @@
         "canton": "SO"
     },
     {
-        "city": "Wisen SO",
+        "city": "Wisen",
         "zipcode": 4634,
         "canton": "SO"
     },
@@ -11430,7 +11470,7 @@
         "canton": "SO"
     },
     {
-        "city": "Wisen SO",
+        "city": "Wisen",
         "zipcode": 4634,
         "canton": "SO"
     },
@@ -11445,12 +11485,12 @@
         "canton": "SO"
     },
     {
-        "city": "Wisen SO",
+        "city": "Wisen",
         "zipcode": 4634,
         "canton": "SO"
     },
     {
-        "city": "Erlinsbach SO",
+        "city": "Erlinsbach",
         "zipcode": 5015,
         "canton": "SO"
     },
@@ -11465,7 +11505,7 @@
         "canton": "SO"
     },
     {
-        "city": "Aeschi SO",
+        "city": "Aeschi",
         "zipcode": 4556,
         "canton": "SO"
     },
@@ -11475,7 +11515,7 @@
         "canton": "SO"
     },
     {
-        "city": "Steinhof SO",
+        "city": "Steinhof",
         "zipcode": 4556,
         "canton": "SO"
     },
@@ -11720,7 +11760,7 @@
         "canton": "SO"
     },
     {
-        "city": "Oberdorf SO",
+        "city": "Oberdorf",
         "zipcode": 4515,
         "canton": "SO"
     },
@@ -11735,7 +11775,7 @@
         "canton": "SO"
     },
     {
-        "city": "Niederwil SO",
+        "city": "Niederwil",
         "zipcode": 4523,
         "canton": "SO"
     },
@@ -11785,7 +11825,7 @@
         "canton": "SO"
     },
     {
-        "city": "D\u00e4niken SO",
+        "city": "D\u00e4niken",
         "zipcode": 4658,
         "canton": "SO"
     },
@@ -11795,7 +11835,7 @@
         "canton": "SO"
     },
     {
-        "city": "Walterswil SO",
+        "city": "Walterswil",
         "zipcode": 5746,
         "canton": "SO"
     },
@@ -11815,7 +11855,7 @@
         "canton": "SO"
     },
     {
-        "city": "D\u00e4niken SO",
+        "city": "D\u00e4niken",
         "zipcode": 4658,
         "canton": "SO"
     },
@@ -11830,7 +11870,7 @@
         "canton": "SO"
     },
     {
-        "city": "Kappel SO",
+        "city": "Kappel",
         "zipcode": 4616,
         "canton": "SO"
     },
@@ -11855,7 +11895,7 @@
         "canton": "SO"
     },
     {
-        "city": "Kappel SO",
+        "city": "Kappel",
         "zipcode": 4616,
         "canton": "SO"
     },
@@ -11880,7 +11920,7 @@
         "canton": "SO"
     },
     {
-        "city": "Rickenbach SO",
+        "city": "Rickenbach",
         "zipcode": 4613,
         "canton": "SO"
     },
@@ -11905,7 +11945,7 @@
         "canton": "SO"
     },
     {
-        "city": "Walterswil SO",
+        "city": "Walterswil",
         "zipcode": 5746,
         "canton": "SO"
     },
@@ -11940,7 +11980,7 @@
         "canton": "SO"
     },
     {
-        "city": "Beinwil SO",
+        "city": "Beinwil",
         "zipcode": 4229,
         "canton": "SO"
     },
@@ -11990,7 +12030,7 @@
         "canton": "SO"
     },
     {
-        "city": "Seewen SO",
+        "city": "Seewen",
         "zipcode": 4206,
         "canton": "SO"
     },
@@ -12005,7 +12045,7 @@
         "canton": "SO"
     },
     {
-        "city": "Beinwil SO",
+        "city": "Beinwil",
         "zipcode": 4229,
         "canton": "SO"
     },
@@ -12115,12 +12155,12 @@
         "canton": "BS"
     },
     {
-        "city": "Aesch BL",
+        "city": "Aesch",
         "zipcode": 4147,
         "canton": "BL"
     },
     {
-        "city": "Reinach BL",
+        "city": "Reinach",
         "zipcode": 4153,
         "canton": "BL"
     },
@@ -12135,7 +12175,7 @@
         "canton": "BL"
     },
     {
-        "city": "Biel-Benken BL",
+        "city": "Biel-Benken",
         "zipcode": 4105,
         "canton": "BL"
     },
@@ -12190,7 +12230,7 @@
         "canton": "BL"
     },
     {
-        "city": "Reinach BL",
+        "city": "Reinach",
         "zipcode": 4153,
         "canton": "BL"
     },
@@ -12215,12 +12255,12 @@
         "canton": "BL"
     },
     {
-        "city": "Oberwil BL",
+        "city": "Oberwil",
         "zipcode": 4104,
         "canton": "BL"
     },
     {
-        "city": "Aesch BL",
+        "city": "Aesch",
         "zipcode": 4147,
         "canton": "BL"
     },
@@ -12235,7 +12275,7 @@
         "canton": "BL"
     },
     {
-        "city": "Reinach BL",
+        "city": "Reinach",
         "zipcode": 4153,
         "canton": "BL"
     },
@@ -12250,7 +12290,7 @@
         "canton": "BL"
     },
     {
-        "city": "Reinach BL",
+        "city": "Reinach",
         "zipcode": 4153,
         "canton": "BL"
     },
@@ -12365,7 +12405,7 @@
         "canton": "BL"
     },
     {
-        "city": "Augst BL",
+        "city": "Augst",
         "zipcode": 4302,
         "canton": "BL"
     },
@@ -12445,7 +12485,7 @@
         "canton": "BL"
     },
     {
-        "city": "Augst BL",
+        "city": "Augst",
         "zipcode": 4302,
         "canton": "BL"
     },
@@ -12510,7 +12550,7 @@
         "canton": "BL"
     },
     {
-        "city": "Rickenbach BL",
+        "city": "Rickenbach",
         "zipcode": 4462,
         "canton": "BL"
     },
@@ -12580,7 +12620,7 @@
         "canton": "BL"
     },
     {
-        "city": "Kilchberg BL",
+        "city": "Kilchberg",
         "zipcode": 4496,
         "canton": "BL"
     },
@@ -12600,7 +12640,7 @@
         "canton": "BL"
     },
     {
-        "city": "Wisen SO",
+        "city": "Wisen",
         "zipcode": 4634,
         "canton": "BL"
     },
@@ -12640,7 +12680,7 @@
         "canton": "BL"
     },
     {
-        "city": "Rickenbach BL",
+        "city": "Rickenbach",
         "zipcode": 4462,
         "canton": "BL"
     },
@@ -12810,7 +12850,7 @@
         "canton": "BL"
     },
     {
-        "city": "Beinwil SO",
+        "city": "Beinwil",
         "zipcode": 4229,
         "canton": "BL"
     },
@@ -12850,7 +12890,7 @@
         "canton": "BL"
     },
     {
-        "city": "Oberdorf BL",
+        "city": "Oberdorf",
         "zipcode": 4436,
         "canton": "BL"
     },
@@ -12860,7 +12900,7 @@
         "canton": "BL"
     },
     {
-        "city": "Oberdorf BL",
+        "city": "Oberdorf",
         "zipcode": 4436,
         "canton": "BL"
     },
@@ -12960,17 +13000,17 @@
         "canton": "SH"
     },
     {
-        "city": "Lohn SH",
+        "city": "Lohn",
         "zipcode": 8235,
         "canton": "SH"
     },
     {
-        "city": "Stetten SH",
+        "city": "Stetten",
         "zipcode": 8234,
         "canton": "SH"
     },
     {
-        "city": "Opfertshofen SH",
+        "city": "Opfertshofen",
         "zipcode": 8236,
         "canton": "SH"
     },
@@ -12985,22 +13025,22 @@
         "canton": "SH"
     },
     {
-        "city": "Bibern SH",
+        "city": "Bibern",
         "zipcode": 8242,
         "canton": "SH"
     },
     {
-        "city": "Hofen SH",
+        "city": "Hofen",
         "zipcode": 8242,
         "canton": "SH"
     },
     {
-        "city": "Altdorf SH",
+        "city": "Altdorf",
         "zipcode": 8243,
         "canton": "SH"
     },
     {
-        "city": "Bargen SH",
+        "city": "Bargen",
         "zipcode": 8233,
         "canton": "SH"
     },
@@ -13080,6 +13120,11 @@
         "canton": "SH"
     },
     {
+        "city": "Schleitheim",
+        "zipcode": 8226,
+        "canton": "SH"
+    },
+    {
         "city": "Beggingen",
         "zipcode": 8228,
         "canton": "SH"
@@ -13095,7 +13140,7 @@
         "canton": "SH"
     },
     {
-        "city": "Buch SH",
+        "city": "Buch",
         "zipcode": 8263,
         "canton": "SH"
     },
@@ -13160,12 +13205,12 @@
         "canton": "AR"
     },
     {
-        "city": "Gossau SG",
+        "city": "Gossau",
         "zipcode": 9200,
         "canton": "AR"
     },
     {
-        "city": "Stein AR",
+        "city": "Stein",
         "zipcode": 9063,
         "canton": "AR"
     },
@@ -13225,7 +13270,7 @@
         "canton": "AR"
     },
     {
-        "city": "Stein AR",
+        "city": "Stein",
         "zipcode": 9063,
         "canton": "AR"
     },
@@ -13285,7 +13330,7 @@
         "canton": "AR"
     },
     {
-        "city": "Altst\u00e4tten SG",
+        "city": "Altst\u00e4tten",
         "zipcode": 9450,
         "canton": "AR"
     },
@@ -13315,7 +13360,7 @@
         "canton": "AR"
     },
     {
-        "city": "Teufen AR",
+        "city": "Teufen",
         "zipcode": 9053,
         "canton": "AR"
     },
@@ -13335,7 +13380,7 @@
         "canton": "AR"
     },
     {
-        "city": "Grub AR",
+        "city": "Grub",
         "zipcode": 9035,
         "canton": "AR"
     },
@@ -13345,7 +13390,7 @@
         "canton": "AR"
     },
     {
-        "city": "Grub SG",
+        "city": "Grub",
         "zipcode": 9036,
         "canton": "AR"
     },
@@ -13400,7 +13445,7 @@
         "canton": "AR"
     },
     {
-        "city": "Reute AR",
+        "city": "Reute",
         "zipcode": 9411,
         "canton": "AR"
     },
@@ -13410,7 +13455,7 @@
         "canton": "AR"
     },
     {
-        "city": "Marbach SG",
+        "city": "Marbach",
         "zipcode": 9437,
         "canton": "AR"
     },
@@ -13420,7 +13465,7 @@
         "canton": "AR"
     },
     {
-        "city": "Wald AR",
+        "city": "Wald",
         "zipcode": 9044,
         "canton": "AR"
     },
@@ -13515,12 +13560,12 @@
         "canton": "AI"
     },
     {
-        "city": "Teufen AR",
+        "city": "Teufen",
         "zipcode": 9053,
         "canton": "AI"
     },
     {
-        "city": "Haslen AI",
+        "city": "Haslen",
         "zipcode": 9054,
         "canton": "AI"
     },
@@ -13705,7 +13750,7 @@
         "canton": "SG"
     },
     {
-        "city": "Abtwil SG",
+        "city": "Abtwil",
         "zipcode": 9030,
         "canton": "SG"
     },
@@ -13745,12 +13790,12 @@
         "canton": "SG"
     },
     {
-        "city": "Berg SG",
+        "city": "Berg",
         "zipcode": 9305,
         "canton": "SG"
     },
     {
-        "city": "Freidorf TG",
+        "city": "Freidorf",
         "zipcode": 9306,
         "canton": "SG"
     },
@@ -13760,12 +13805,12 @@
         "canton": "SG"
     },
     {
-        "city": "Grub AR",
+        "city": "Grub",
         "zipcode": 9035,
         "canton": "SG"
     },
     {
-        "city": "Grub SG",
+        "city": "Grub",
         "zipcode": 9036,
         "canton": "SG"
     },
@@ -13815,12 +13860,12 @@
         "canton": "SG"
     },
     {
-        "city": "Staad SG",
+        "city": "Staad",
         "zipcode": 9422,
         "canton": "SG"
     },
     {
-        "city": "Berg SG",
+        "city": "Berg",
         "zipcode": 9305,
         "canton": "SG"
     },
@@ -13850,7 +13895,7 @@
         "canton": "SG"
     },
     {
-        "city": "Au SG",
+        "city": "Au",
         "zipcode": 9434,
         "canton": "SG"
     },
@@ -13875,12 +13920,12 @@
         "canton": "SG"
     },
     {
-        "city": "Reute AR",
+        "city": "Reute",
         "zipcode": 9411,
         "canton": "SG"
     },
     {
-        "city": "Au SG",
+        "city": "Au",
         "zipcode": 9434,
         "canton": "SG"
     },
@@ -13940,7 +13985,7 @@
         "canton": "SG"
     },
     {
-        "city": "St. Margrethen SG",
+        "city": "St. Margrethen",
         "zipcode": 9430,
         "canton": "SG"
     },
@@ -13950,7 +13995,7 @@
         "canton": "SG"
     },
     {
-        "city": "Staad SG",
+        "city": "Staad",
         "zipcode": 9422,
         "canton": "SG"
     },
@@ -13980,7 +14025,7 @@
         "canton": "SG"
     },
     {
-        "city": "Altst\u00e4tten SG",
+        "city": "Altst\u00e4tten",
         "zipcode": 9450,
         "canton": "SG"
     },
@@ -14000,7 +14045,7 @@
         "canton": "SG"
     },
     {
-        "city": "Oberriet SG",
+        "city": "Oberriet",
         "zipcode": 9463,
         "canton": "SG"
     },
@@ -14025,7 +14070,7 @@
         "canton": "SG"
     },
     {
-        "city": "Marbach SG",
+        "city": "Marbach",
         "zipcode": 9437,
         "canton": "SG"
     },
@@ -14045,12 +14090,12 @@
         "canton": "SG"
     },
     {
-        "city": "Oberriet SG",
+        "city": "Oberriet",
         "zipcode": 9463,
         "canton": "SG"
     },
     {
-        "city": "Marbach SG",
+        "city": "Marbach",
         "zipcode": 9437,
         "canton": "SG"
     },
@@ -14060,7 +14105,7 @@
         "canton": "SG"
     },
     {
-        "city": "Oberriet SG",
+        "city": "Oberriet",
         "zipcode": 9463,
         "canton": "SG"
     },
@@ -14080,7 +14125,7 @@
         "canton": "SG"
     },
     {
-        "city": "Buchs SG",
+        "city": "Buchs",
         "zipcode": 9470,
         "canton": "SG"
     },
@@ -14100,7 +14145,7 @@
         "canton": "SG"
     },
     {
-        "city": "Buchs SG",
+        "city": "Buchs",
         "zipcode": 9470,
         "canton": "SG"
     },
@@ -14155,7 +14200,7 @@
         "canton": "SG"
     },
     {
-        "city": "Buchs SG",
+        "city": "Buchs",
         "zipcode": 9470,
         "canton": "SG"
     },
@@ -14200,7 +14245,7 @@
         "canton": "SG"
     },
     {
-        "city": "Malans SG",
+        "city": "Malans",
         "zipcode": 9479,
         "canton": "SG"
     },
@@ -14435,17 +14480,17 @@
         "canton": "SG"
     },
     {
-        "city": "Benken SG",
+        "city": "Benken",
         "zipcode": 8717,
         "canton": "SG"
     },
     {
-        "city": "Buttikon SZ",
+        "city": "Buttikon",
         "zipcode": 8863,
         "canton": "SG"
     },
     {
-        "city": "Benken SG",
+        "city": "Benken",
         "zipcode": 8717,
         "canton": "SG"
     },
@@ -14505,7 +14550,7 @@
         "canton": "SG"
     },
     {
-        "city": "R\u00fcti ZH",
+        "city": "R\u00fcti",
         "zipcode": 8630,
         "canton": "SG"
     },
@@ -14515,7 +14560,7 @@
         "canton": "SG"
     },
     {
-        "city": "Rapperswil SG",
+        "city": "Rapperswil",
         "zipcode": 8640,
         "canton": "SG"
     },
@@ -14555,7 +14600,7 @@
         "canton": "SG"
     },
     {
-        "city": "Ricken SG",
+        "city": "Ricken",
         "zipcode": 8726,
         "canton": "SG"
     },
@@ -14570,22 +14615,22 @@
         "canton": "SG"
     },
     {
-        "city": "Uetliburg SG",
+        "city": "Uetliburg",
         "zipcode": 8738,
         "canton": "SG"
     },
     {
-        "city": "Rieden SG",
+        "city": "Rieden",
         "zipcode": 8739,
         "canton": "SG"
     },
     {
-        "city": "Wald ZH",
+        "city": "Wald",
         "zipcode": 8636,
         "canton": "SG"
     },
     {
-        "city": "Laupen ZH",
+        "city": "Laupen",
         "zipcode": 8637,
         "canton": "SG"
     },
@@ -14600,17 +14645,17 @@
         "canton": "SG"
     },
     {
-        "city": "Walde SG",
+        "city": "Walde",
         "zipcode": 8727,
         "canton": "SG"
     },
     {
-        "city": "Neuhaus SG",
+        "city": "Neuhaus",
         "zipcode": 8732,
         "canton": "SG"
     },
     {
-        "city": "Eschenbach SG",
+        "city": "Eschenbach",
         "zipcode": 8733,
         "canton": "SG"
     },
@@ -14695,7 +14740,7 @@
         "canton": "SG"
     },
     {
-        "city": "Stein SG",
+        "city": "Stein",
         "zipcode": 9655,
         "canton": "SG"
     },
@@ -14705,7 +14750,7 @@
         "canton": "SG"
     },
     {
-        "city": "Ricken SG",
+        "city": "Ricken",
         "zipcode": 8726,
         "canton": "SG"
     },
@@ -14750,7 +14795,7 @@
         "canton": "SG"
     },
     {
-        "city": "Wil SG",
+        "city": "Wil",
         "zipcode": 9500,
         "canton": "SG"
     },
@@ -14760,7 +14805,7 @@
         "canton": "SG"
     },
     {
-        "city": "Kirchberg SG",
+        "city": "Kirchberg",
         "zipcode": 9533,
         "canton": "SG"
     },
@@ -14835,7 +14880,7 @@
         "canton": "SG"
     },
     {
-        "city": "Au TG",
+        "city": "Au",
         "zipcode": 8376,
         "canton": "SG"
     },
@@ -15015,12 +15060,17 @@
         "canton": "SG"
     },
     {
+        "city": "Flawil",
+        "zipcode": 9230,
+        "canton": "SG"
+    },
+    {
         "city": "Degersheim",
         "zipcode": 9113,
         "canton": "SG"
     },
     {
-        "city": "Gossau SG",
+        "city": "Gossau",
         "zipcode": 9200,
         "canton": "SG"
     },
@@ -15050,7 +15100,7 @@
         "canton": "SG"
     },
     {
-        "city": "Schwarzenbach SG",
+        "city": "Schwarzenbach",
         "zipcode": 9536,
         "canton": "SG"
     },
@@ -15065,7 +15115,7 @@
         "canton": "SG"
     },
     {
-        "city": "Niederglatt SG",
+        "city": "Niederglatt",
         "zipcode": 9240,
         "canton": "SG"
     },
@@ -15125,17 +15175,17 @@
         "canton": "SG"
     },
     {
-        "city": "Schwarzenbach SG",
+        "city": "Schwarzenbach",
         "zipcode": 9536,
         "canton": "SG"
     },
     {
-        "city": "Gossau SG",
+        "city": "Gossau",
         "zipcode": 9200,
         "canton": "SG"
     },
     {
-        "city": "Niederwil SG",
+        "city": "Niederwil",
         "zipcode": 9203,
         "canton": "SG"
     },
@@ -15155,6 +15205,16 @@
         "canton": "SG"
     },
     {
+        "city": "Sonnental",
+        "zipcode": 9245,
+        "canton": "SG"
+    },
+    {
+        "city": "Zuzwil",
+        "zipcode": 9524,
+        "canton": "SG"
+    },
+    {
         "city": "Lenggenwil",
         "zipcode": 9525,
         "canton": "SG"
@@ -15170,7 +15230,7 @@
         "canton": "SG"
     },
     {
-        "city": "Niederwil SG",
+        "city": "Niederwil",
         "zipcode": 9203,
         "canton": "SG"
     },
@@ -15180,7 +15240,7 @@
         "canton": "SG"
     },
     {
-        "city": "Niederglatt SG",
+        "city": "Niederglatt",
         "zipcode": 9240,
         "canton": "SG"
     },
@@ -15195,7 +15255,7 @@
         "canton": "SG"
     },
     {
-        "city": "Wil SG",
+        "city": "Wil",
         "zipcode": 9500,
         "canton": "SG"
     },
@@ -15210,12 +15270,12 @@
         "canton": "SG"
     },
     {
-        "city": "Zuzwil SG",
+        "city": "Zuzwil",
         "zipcode": 9524,
         "canton": "SG"
     },
     {
-        "city": "Wil SG",
+        "city": "Wil",
         "zipcode": 9500,
         "canton": "SG"
     },
@@ -15230,17 +15290,17 @@
         "canton": "SG"
     },
     {
-        "city": "Zuzwil SG",
+        "city": "Zuzwil",
         "zipcode": 9524,
         "canton": "SG"
     },
     {
-        "city": "Schwarzenbach SG",
+        "city": "Schwarzenbach",
         "zipcode": 9536,
         "canton": "SG"
     },
     {
-        "city": "St. Margarethen TG",
+        "city": "St. Margarethen",
         "zipcode": 9543,
         "canton": "SG"
     },
@@ -15250,7 +15310,7 @@
         "canton": "SG"
     },
     {
-        "city": "Andwil SG",
+        "city": "Andwil",
         "zipcode": 9204,
         "canton": "SG"
     },
@@ -15260,7 +15320,7 @@
         "canton": "SG"
     },
     {
-        "city": "Abtwil SG",
+        "city": "Abtwil",
         "zipcode": 9030,
         "canton": "SG"
     },
@@ -15285,7 +15345,7 @@
         "canton": "SG"
     },
     {
-        "city": "Abtwil SG",
+        "city": "Abtwil",
         "zipcode": 9030,
         "canton": "SG"
     },
@@ -15295,12 +15355,12 @@
         "canton": "SG"
     },
     {
-        "city": "Gossau SG",
+        "city": "Gossau",
         "zipcode": 9200,
         "canton": "SG"
     },
     {
-        "city": "Andwil SG",
+        "city": "Andwil",
         "zipcode": 9204,
         "canton": "SG"
     },
@@ -15315,7 +15375,7 @@
         "canton": "SG"
     },
     {
-        "city": "Andwil SG",
+        "city": "Andwil",
         "zipcode": 9204,
         "canton": "SG"
     },
@@ -15375,7 +15435,7 @@
         "canton": "GR"
     },
     {
-        "city": "Brienz\/Brinzauls GR",
+        "city": "Brienz\/Brinzauls",
         "zipcode": 7084,
         "canton": "GR"
     },
@@ -15585,7 +15645,7 @@
         "canton": "GR"
     },
     {
-        "city": "Laax GR",
+        "city": "Laax",
         "zipcode": 7031,
         "canton": "GR"
     },
@@ -16020,7 +16080,7 @@
         "canton": "GR"
     },
     {
-        "city": "Lohn GR",
+        "city": "Lohn",
         "zipcode": 7433,
         "canton": "GR"
     },
@@ -16460,7 +16520,7 @@
         "canton": "GR"
     },
     {
-        "city": "Roveredo GR",
+        "city": "Roveredo",
         "zipcode": 6535,
         "canton": "GR"
     },
@@ -16840,7 +16900,7 @@
         "canton": "GR"
     },
     {
-        "city": "Malans GR",
+        "city": "Malans",
         "zipcode": 7208,
         "canton": "GR"
     },
@@ -17115,7 +17175,7 @@
         "canton": "AG"
     },
     {
-        "city": "Buchs AG",
+        "city": "Buchs",
         "zipcode": 5033,
         "canton": "AG"
     },
@@ -17145,7 +17205,7 @@
         "canton": "AG"
     },
     {
-        "city": "Teufenthal AG",
+        "city": "Teufenthal",
         "zipcode": 5723,
         "canton": "AG"
     },
@@ -17205,7 +17265,7 @@
         "canton": "AG"
     },
     {
-        "city": "D\u00e4ttwil AG",
+        "city": "D\u00e4ttwil",
         "zipcode": 5405,
         "canton": "AG"
     },
@@ -17240,7 +17300,7 @@
         "canton": "AG"
     },
     {
-        "city": "Birmenstorf AG",
+        "city": "Birmenstorf",
         "zipcode": 5413,
         "canton": "AG"
     },
@@ -17250,7 +17310,7 @@
         "canton": "AG"
     },
     {
-        "city": "D\u00e4ttwil AG",
+        "city": "D\u00e4ttwil",
         "zipcode": 5405,
         "canton": "AG"
     },
@@ -17270,7 +17330,7 @@
         "canton": "AG"
     },
     {
-        "city": "Vogelsang AG",
+        "city": "Vogelsang",
         "zipcode": 5412,
         "canton": "AG"
     },
@@ -17310,22 +17370,22 @@
         "canton": "AG"
     },
     {
-        "city": "Nussbaumen AG",
+        "city": "Nussbaumen",
         "zipcode": 5415,
         "canton": "AG"
     },
     {
-        "city": "Hertenstein AG",
+        "city": "Hertenstein",
         "zipcode": 5415,
         "canton": "AG"
     },
     {
-        "city": "Rieden AG",
+        "city": "Rieden",
         "zipcode": 5415,
         "canton": "AG"
     },
     {
-        "city": "Kirchdorf AG",
+        "city": "Kirchdorf",
         "zipcode": 5416,
         "canton": "AG"
     },
@@ -17345,7 +17405,7 @@
         "canton": "AG"
     },
     {
-        "city": "Stetten AG",
+        "city": "Stetten",
         "zipcode": 5608,
         "canton": "AG"
     },
@@ -17360,7 +17420,7 @@
         "canton": "AG"
     },
     {
-        "city": "Kirchdorf AG",
+        "city": "Kirchdorf",
         "zipcode": 5416,
         "canton": "AG"
     },
@@ -17410,7 +17470,7 @@
         "canton": "AG"
     },
     {
-        "city": "Arni AG",
+        "city": "Arni",
         "zipcode": 8905,
         "canton": "AG"
     },
@@ -17425,7 +17485,7 @@
         "canton": "AG"
     },
     {
-        "city": "Bremgarten AG",
+        "city": "Bremgarten",
         "zipcode": 5620,
         "canton": "AG"
     },
@@ -17435,7 +17495,7 @@
         "canton": "AG"
     },
     {
-        "city": "B\u00fcttikon AG",
+        "city": "B\u00fcttikon",
         "zipcode": 5619,
         "canton": "AG"
     },
@@ -17475,7 +17535,7 @@
         "canton": "AG"
     },
     {
-        "city": "Niederwil AG",
+        "city": "Niederwil",
         "zipcode": 5524,
         "canton": "AG"
     },
@@ -17530,7 +17590,7 @@
         "canton": "AG"
     },
     {
-        "city": "Wohlen AG",
+        "city": "Wohlen",
         "zipcode": 5610,
         "canton": "AG"
     },
@@ -17555,7 +17615,7 @@
         "canton": "AG"
     },
     {
-        "city": "Wohlen AG",
+        "city": "Wohlen",
         "zipcode": 5610,
         "canton": "AG"
     },
@@ -17600,7 +17660,7 @@
         "canton": "AG"
     },
     {
-        "city": "Brugg AG",
+        "city": "Brugg",
         "zipcode": 5200,
         "canton": "AG"
     },
@@ -17625,12 +17685,12 @@
         "canton": "AG"
     },
     {
-        "city": "Hausen AG",
+        "city": "Hausen",
         "zipcode": 5212,
         "canton": "AG"
     },
     {
-        "city": "Hausen AG",
+        "city": "Hausen",
         "zipcode": 5212,
         "canton": "AG"
     },
@@ -17675,22 +17735,22 @@
         "canton": "AG"
     },
     {
-        "city": "Brugg AG",
+        "city": "Brugg",
         "zipcode": 5200,
         "canton": "AG"
     },
     {
-        "city": "R\u00fcfenach AG",
+        "city": "R\u00fcfenach",
         "zipcode": 5235,
         "canton": "AG"
     },
     {
-        "city": "Thalheim AG",
+        "city": "Thalheim",
         "zipcode": 5112,
         "canton": "AG"
     },
     {
-        "city": "Veltheim AG",
+        "city": "Veltheim",
         "zipcode": 5106,
         "canton": "AG"
     },
@@ -17780,7 +17840,7 @@
         "canton": "AG"
     },
     {
-        "city": "Walde AG",
+        "city": "Walde",
         "zipcode": 5046,
         "canton": "AG"
     },
@@ -17795,7 +17855,7 @@
         "canton": "AG"
     },
     {
-        "city": "Leimbach AG",
+        "city": "Leimbach",
         "zipcode": 5733,
         "canton": "AG"
     },
@@ -17810,7 +17870,7 @@
         "canton": "AG"
     },
     {
-        "city": "Burg AG",
+        "city": "Burg",
         "zipcode": 5736,
         "canton": "AG"
     },
@@ -17825,7 +17885,7 @@
         "canton": "AG"
     },
     {
-        "city": "Reinach AG",
+        "city": "Reinach",
         "zipcode": 5734,
         "canton": "AG"
     },
@@ -17840,7 +17900,7 @@
         "canton": "AG"
     },
     {
-        "city": "Walde AG",
+        "city": "Walde",
         "zipcode": 5046,
         "canton": "AG"
     },
@@ -17850,7 +17910,7 @@
         "canton": "AG"
     },
     {
-        "city": "Teufenthal AG",
+        "city": "Teufenthal",
         "zipcode": 5723,
         "canton": "AG"
     },
@@ -17865,7 +17925,7 @@
         "canton": "AG"
     },
     {
-        "city": "Teufenthal AG",
+        "city": "Teufenthal",
         "zipcode": 5723,
         "canton": "AG"
     },
@@ -17930,12 +17990,12 @@
         "canton": "AG"
     },
     {
-        "city": "Sulz AG",
+        "city": "Sulz",
         "zipcode": 5085,
         "canton": "AG"
     },
     {
-        "city": "M\u00fcnchwilen AG",
+        "city": "M\u00fcnchwilen",
         "zipcode": 4333,
         "canton": "AG"
     },
@@ -17955,7 +18015,7 @@
         "canton": "AG"
     },
     {
-        "city": "Sisseln AG",
+        "city": "Sisseln",
         "zipcode": 4334,
         "canton": "AG"
     },
@@ -17980,7 +18040,7 @@
         "canton": "AG"
     },
     {
-        "city": "Oberhofen AG",
+        "city": "Oberhofen",
         "zipcode": 5273,
         "canton": "AG"
     },
@@ -17995,7 +18055,7 @@
         "canton": "AG"
     },
     {
-        "city": "Wil AG",
+        "city": "Wil",
         "zipcode": 5276,
         "canton": "AG"
     },
@@ -18035,7 +18095,7 @@
         "canton": "AG"
     },
     {
-        "city": "Ammerswil AG",
+        "city": "Ammerswil",
         "zipcode": 5600,
         "canton": "AG"
     },
@@ -18085,7 +18145,7 @@
         "canton": "AG"
     },
     {
-        "city": "Holderbank AG",
+        "city": "Holderbank",
         "zipcode": 5113,
         "canton": "AG"
     },
@@ -18120,7 +18180,7 @@
         "canton": "AG"
     },
     {
-        "city": "M\u00f6riken AG",
+        "city": "M\u00f6riken",
         "zipcode": 5103,
         "canton": "AG"
     },
@@ -18175,7 +18235,7 @@
         "canton": "AG"
     },
     {
-        "city": "Abtwil AG",
+        "city": "Abtwil",
         "zipcode": 5646,
         "canton": "AG"
     },
@@ -18185,7 +18245,7 @@
         "canton": "AG"
     },
     {
-        "city": "Muri AG",
+        "city": "Muri",
         "zipcode": 5630,
         "canton": "AG"
     },
@@ -18240,6 +18300,11 @@
         "canton": "AG"
     },
     {
+        "city": "Muri",
+        "zipcode": 5630,
+        "canton": "AG"
+    },
+    {
         "city": "Buttwil",
         "zipcode": 5632,
         "canton": "AG"
@@ -18250,7 +18315,7 @@
         "canton": "AG"
     },
     {
-        "city": "Waldh\u00e4usern AG",
+        "city": "Waldh\u00e4usern",
         "zipcode": 5624,
         "canton": "AG"
     },
@@ -18295,7 +18360,7 @@
         "canton": "AG"
     },
     {
-        "city": "Muri AG",
+        "city": "Muri",
         "zipcode": 5630,
         "canton": "AG"
     },
@@ -18337,6 +18402,16 @@
     {
         "city": "Fenkrieden",
         "zipcode": 5645,
+        "canton": "AG"
+    },
+    {
+        "city": "Inwil",
+        "zipcode": 6034,
+        "canton": "AG"
+    },
+    {
+        "city": "Ballwil",
+        "zipcode": 6275,
         "canton": "AG"
     },
     {
@@ -18410,7 +18485,7 @@
         "canton": "AG"
     },
     {
-        "city": "Stein AG",
+        "city": "Stein",
         "zipcode": 4332,
         "canton": "AG"
     },
@@ -18510,7 +18585,7 @@
         "canton": "AG"
     },
     {
-        "city": "Riken AG",
+        "city": "Riken",
         "zipcode": 4853,
         "canton": "AG"
     },
@@ -18520,7 +18595,7 @@
         "canton": "AG"
     },
     {
-        "city": "Roggwil BE",
+        "city": "Roggwil",
         "zipcode": 4914,
         "canton": "AG"
     },
@@ -18680,7 +18755,7 @@
         "canton": "AG"
     },
     {
-        "city": "Lengnau AG",
+        "city": "Lengnau",
         "zipcode": 5426,
         "canton": "AG"
     },
@@ -18725,7 +18800,7 @@
         "canton": "AG"
     },
     {
-        "city": "Rekingen AG",
+        "city": "Rekingen",
         "zipcode": 5332,
         "canton": "AG"
     },
@@ -18745,12 +18820,12 @@
         "canton": "AG"
     },
     {
-        "city": "R\u00fcmikon AG",
+        "city": "R\u00fcmikon",
         "zipcode": 5464,
         "canton": "AG"
     },
     {
-        "city": "Kaiserstuhl AG",
+        "city": "Kaiserstuhl",
         "zipcode": 5466,
         "canton": "AG"
     },
@@ -18810,7 +18885,7 @@
         "canton": "TG"
     },
     {
-        "city": "Freidorf TG",
+        "city": "Freidorf",
         "zipcode": 9306,
         "canton": "TG"
     },
@@ -18835,7 +18910,7 @@
         "canton": "TG"
     },
     {
-        "city": "Roggwil TG",
+        "city": "Roggwil",
         "zipcode": 9325,
         "canton": "TG"
     },
@@ -19055,7 +19130,7 @@
         "canton": "TG"
     },
     {
-        "city": "Schlatt TG",
+        "city": "Schlatt",
         "zipcode": 8252,
         "canton": "TG"
     },
@@ -19070,7 +19145,7 @@
         "canton": "TG"
     },
     {
-        "city": "Schlatt TG",
+        "city": "Schlatt",
         "zipcode": 8252,
         "canton": "TG"
     },
@@ -19080,7 +19155,7 @@
         "canton": "TG"
     },
     {
-        "city": "Ettenhausen TG",
+        "city": "Ettenhausen",
         "zipcode": 8356,
         "canton": "TG"
     },
@@ -19140,7 +19215,7 @@
         "canton": "TG"
     },
     {
-        "city": "Kefikon TG",
+        "city": "Kefikon",
         "zipcode": 8546,
         "canton": "TG"
     },
@@ -19155,7 +19230,7 @@
         "canton": "TG"
     },
     {
-        "city": "Mettendorf TG",
+        "city": "Mettendorf",
         "zipcode": 8553,
         "canton": "TG"
     },
@@ -19220,7 +19295,7 @@
         "canton": "TG"
     },
     {
-        "city": "Wetzikon TG",
+        "city": "Wetzikon",
         "zipcode": 8512,
         "canton": "TG"
     },
@@ -19240,7 +19315,7 @@
         "canton": "TG"
     },
     {
-        "city": "Weiningen TG",
+        "city": "Weiningen",
         "zipcode": 8532,
         "canton": "TG"
     },
@@ -19365,7 +19440,7 @@
         "canton": "TG"
     },
     {
-        "city": "Oberhofen TG",
+        "city": "Oberhofen",
         "zipcode": 8574,
         "canton": "TG"
     },
@@ -19500,7 +19575,7 @@
         "canton": "TG"
     },
     {
-        "city": "Eschlikon TG",
+        "city": "Eschlikon",
         "zipcode": 8360,
         "canton": "TG"
     },
@@ -19525,7 +19600,7 @@
         "canton": "TG"
     },
     {
-        "city": "Oberwangen TG",
+        "city": "Oberwangen",
         "zipcode": 8374,
         "canton": "TG"
     },
@@ -19535,7 +19610,7 @@
         "canton": "TG"
     },
     {
-        "city": "Au TG",
+        "city": "Au",
         "zipcode": 8376,
         "canton": "TG"
     },
@@ -19560,22 +19635,22 @@
         "canton": "TG"
     },
     {
-        "city": "Eschlikon TG",
+        "city": "Eschlikon",
         "zipcode": 8360,
         "canton": "TG"
     },
     {
-        "city": "Wil SG",
+        "city": "Wil",
         "zipcode": 9500,
         "canton": "TG"
     },
     {
-        "city": "M\u00fcnchwilen TG",
+        "city": "M\u00fcnchwilen",
         "zipcode": 9542,
         "canton": "TG"
     },
     {
-        "city": "St. Margarethen TG",
+        "city": "St. Margarethen",
         "zipcode": 9543,
         "canton": "TG"
     },
@@ -19590,7 +19665,7 @@
         "canton": "TG"
     },
     {
-        "city": "Schwarzenbach SG",
+        "city": "Schwarzenbach",
         "zipcode": 9536,
         "canton": "TG"
     },
@@ -19605,7 +19680,7 @@
         "canton": "TG"
     },
     {
-        "city": "Busswil TG",
+        "city": "Busswil",
         "zipcode": 8371,
         "canton": "TG"
     },
@@ -19670,7 +19745,7 @@
         "canton": "TG"
     },
     {
-        "city": "Weiningen TG",
+        "city": "Weiningen",
         "zipcode": 8532,
         "canton": "TG"
     },
@@ -19705,7 +19780,7 @@
         "canton": "TG"
     },
     {
-        "city": "Nussbaumen TG",
+        "city": "Nussbaumen",
         "zipcode": 8537,
         "canton": "TG"
     },
@@ -19810,12 +19885,12 @@
         "canton": "TG"
     },
     {
-        "city": "Berg TG",
+        "city": "Berg",
         "zipcode": 8572,
         "canton": "TG"
     },
     {
-        "city": "Berg TG",
+        "city": "Berg",
         "zipcode": 8572,
         "canton": "TG"
     },
@@ -19835,12 +19910,12 @@
         "canton": "TG"
     },
     {
-        "city": "Mauren TG",
+        "city": "Mauren",
         "zipcode": 8576,
         "canton": "TG"
     },
     {
-        "city": "Opfershofen TG",
+        "city": "Opfershofen",
         "zipcode": 8584,
         "canton": "TG"
     },
@@ -19865,7 +19940,7 @@
         "canton": "TG"
     },
     {
-        "city": "Andwil TG",
+        "city": "Andwil",
         "zipcode": 8586,
         "canton": "TG"
     },
@@ -19875,7 +19950,7 @@
         "canton": "TG"
     },
     {
-        "city": "B\u00fcrglen TG",
+        "city": "B\u00fcrglen",
         "zipcode": 8575,
         "canton": "TG"
     },
@@ -19885,17 +19960,17 @@
         "canton": "TG"
     },
     {
-        "city": "Leimbach TG",
+        "city": "Leimbach",
         "zipcode": 8584,
         "canton": "TG"
     },
     {
-        "city": "Opfershofen TG",
+        "city": "Opfershofen",
         "zipcode": 8584,
         "canton": "TG"
     },
     {
-        "city": "B\u00fcrglen TG",
+        "city": "B\u00fcrglen",
         "zipcode": 8575,
         "canton": "TG"
     },
@@ -19965,7 +20040,7 @@
         "canton": "TG"
     },
     {
-        "city": "B\u00fcrglen TG",
+        "city": "B\u00fcrglen",
         "zipcode": 8575,
         "canton": "TG"
     },
@@ -19995,7 +20070,7 @@
         "canton": "TG"
     },
     {
-        "city": "Lamperswil TG",
+        "city": "Lamperswil",
         "zipcode": 8556,
         "canton": "TG"
     },
@@ -20285,7 +20360,7 @@
         "canton": "TI"
     },
     {
-        "city": "Bodio TI",
+        "city": "Bodio",
         "zipcode": 6743,
         "canton": "TI"
     },
@@ -20642,6 +20717,16 @@
     {
         "city": "Cugnasco",
         "zipcode": 6516,
+        "canton": "TI"
+    },
+    {
+        "city": "Contone",
+        "zipcode": 6594,
+        "canton": "TI"
+    },
+    {
+        "city": "Riazzino",
+        "zipcode": 6595,
         "canton": "TI"
     },
     {
@@ -21090,6 +21175,11 @@
         "canton": "TI"
     },
     {
+        "city": "Agno",
+        "zipcode": 6982,
+        "canton": "TI"
+    },
+    {
         "city": "Magliaso",
         "zipcode": 6983,
         "canton": "TI"
@@ -21155,6 +21245,11 @@
         "canton": "TI"
     },
     {
+        "city": "Porza",
+        "zipcode": 6948,
+        "canton": "TI"
+    },
+    {
         "city": "Sorengo",
         "zipcode": 6924,
         "canton": "TI"
@@ -21205,7 +21300,7 @@
         "canton": "TI"
     },
     {
-        "city": "Roveredo TI",
+        "city": "Roveredo",
         "zipcode": 6957,
         "canton": "TI"
     },
@@ -21447,11 +21542,6 @@
     {
         "city": "Seseglio",
         "zipcode": 6832,
-        "canton": "TI"
-    },
-    {
-        "city": "Balerna",
-        "zipcode": 6828,
         "canton": "TI"
     },
     {
@@ -22010,12 +22100,12 @@
         "canton": "VD"
     },
     {
-        "city": "La Forclaz VD",
+        "city": "La Forclaz",
         "zipcode": 1866,
         "canton": "VD"
     },
     {
-        "city": "Ollon VD",
+        "city": "Ollon",
         "zipcode": 1867,
         "canton": "VD"
     },
@@ -22075,7 +22165,7 @@
         "canton": "VD"
     },
     {
-        "city": "La Forclaz VD",
+        "city": "La Forclaz",
         "zipcode": 1866,
         "canton": "VD"
     },
@@ -22090,7 +22180,7 @@
         "canton": "VD"
     },
     {
-        "city": "La Forclaz VD",
+        "city": "La Forclaz",
         "zipcode": 1866,
         "canton": "VD"
     },
@@ -22100,12 +22190,12 @@
         "canton": "VD"
     },
     {
-        "city": "Roche VD",
+        "city": "Roche",
         "zipcode": 1852,
         "canton": "VD"
     },
     {
-        "city": "Villeneuve VD",
+        "city": "Villeneuve",
         "zipcode": 1844,
         "canton": "VD"
     },
@@ -22185,7 +22275,7 @@
         "canton": "VD"
     },
     {
-        "city": "Mollens VD",
+        "city": "Mollens",
         "zipcode": 1146,
         "canton": "VD"
     },
@@ -22255,7 +22345,7 @@
         "canton": "VD"
     },
     {
-        "city": "Bellerive VD",
+        "city": "Bellerive",
         "zipcode": 1585,
         "canton": "VD"
     },
@@ -22285,7 +22375,7 @@
         "canton": "VD"
     },
     {
-        "city": "Mur (Vully) VD",
+        "city": "Mur (Vully)",
         "zipcode": 1787,
         "canton": "VD"
     },
@@ -22405,12 +22495,12 @@
         "canton": "VD"
     },
     {
-        "city": "Mex VD",
+        "city": "Mex",
         "zipcode": 1031,
         "canton": "VD"
     },
     {
-        "city": "Moiry VD",
+        "city": "Moiry",
         "zipcode": 1148,
         "canton": "VD"
     },
@@ -22470,7 +22560,7 @@
         "canton": "VD"
     },
     {
-        "city": "Mex VD",
+        "city": "Mex",
         "zipcode": 1031,
         "canton": "VD"
     },
@@ -22505,7 +22595,7 @@
         "canton": "VD"
     },
     {
-        "city": "Cugy VD",
+        "city": "Cugy",
         "zipcode": 1053,
         "canton": "VD"
     },
@@ -22540,7 +22630,7 @@
         "canton": "VD"
     },
     {
-        "city": "Morrens VD",
+        "city": "Morrens",
         "zipcode": 1054,
         "canton": "VD"
     },
@@ -22570,7 +22660,7 @@
         "canton": "VD"
     },
     {
-        "city": "St-Barth\u00e9lemy VD",
+        "city": "St-Barth\u00e9lemy",
         "zipcode": 1040,
         "canton": "VD"
     },
@@ -22710,7 +22800,7 @@
         "canton": "VD"
     },
     {
-        "city": "Onnens VD",
+        "city": "Onnens",
         "zipcode": 1425,
         "canton": "VD"
     },
@@ -22895,7 +22985,7 @@
         "canton": "VD"
     },
     {
-        "city": "Cugy VD",
+        "city": "Cugy",
         "zipcode": 1053,
         "canton": "VD"
     },
@@ -22935,7 +23025,7 @@
         "canton": "VD"
     },
     {
-        "city": "Renens VD",
+        "city": "Renens",
         "zipcode": 1020,
         "canton": "VD"
     },
@@ -23160,7 +23250,7 @@
         "canton": "VD"
     },
     {
-        "city": "Colombier VD",
+        "city": "Colombier",
         "zipcode": 1114,
         "canton": "VD"
     },
@@ -23175,7 +23265,7 @@
         "canton": "VD"
     },
     {
-        "city": "Ecublens VD",
+        "city": "Ecublens",
         "zipcode": 1024,
         "canton": "VD"
     },
@@ -23200,7 +23290,7 @@
         "canton": "VD"
     },
     {
-        "city": "Lully VD",
+        "city": "Lully",
         "zipcode": 1132,
         "canton": "VD"
     },
@@ -23240,7 +23330,7 @@
         "canton": "VD"
     },
     {
-        "city": "St-Sulpice VD",
+        "city": "St-Sulpice",
         "zipcode": 1025,
         "canton": "VD"
     },
@@ -23280,7 +23370,7 @@
         "canton": "VD"
     },
     {
-        "city": "Cottens VD",
+        "city": "Cottens",
         "zipcode": 1116,
         "canton": "VD"
     },
@@ -23335,7 +23425,7 @@
         "canton": "VD"
     },
     {
-        "city": "Dompierre VD",
+        "city": "Dompierre",
         "zipcode": 1682,
         "canton": "VD"
     },
@@ -23550,7 +23640,7 @@
         "canton": "VD"
     },
     {
-        "city": "Crans VD",
+        "city": "Crans",
         "zipcode": 1299,
         "canton": "VD"
     },
@@ -23662,6 +23752,11 @@
     {
         "city": "Tr\u00e9lex",
         "zipcode": 1270,
+        "canton": "VD"
+    },
+    {
+        "city": "Grens",
+        "zipcode": 1274,
         "canton": "VD"
     },
     {
@@ -23860,7 +23955,7 @@
         "canton": "VD"
     },
     {
-        "city": "Carrouge VD",
+        "city": "Carrouge",
         "zipcode": 1084,
         "canton": "VD"
     },
@@ -23960,17 +24055,17 @@
         "canton": "VD"
     },
     {
-        "city": "Ferlens VD",
+        "city": "Ferlens",
         "zipcode": 1076,
         "canton": "VD"
     },
     {
-        "city": "M\u00e9zi\u00e8res VD",
+        "city": "M\u00e9zi\u00e8res",
         "zipcode": 1083,
         "canton": "VD"
     },
     {
-        "city": "Carrouge VD",
+        "city": "Carrouge",
         "zipcode": 1084,
         "canton": "VD"
     },
@@ -24040,7 +24135,7 @@
         "canton": "VD"
     },
     {
-        "city": "Rossens VD",
+        "city": "Rossens",
         "zipcode": 1554,
         "canton": "VD"
     },
@@ -24090,7 +24185,7 @@
         "canton": "VD"
     },
     {
-        "city": "Cerniaz VD",
+        "city": "Cerniaz",
         "zipcode": 1682,
         "canton": "VD"
     },
@@ -24555,7 +24650,7 @@
         "canton": "VD"
     },
     {
-        "city": "Ependes VD",
+        "city": "Ependes",
         "zipcode": 1434,
         "canton": "VD"
     },
@@ -25010,7 +25105,7 @@
         "canton": "VS"
     },
     {
-        "city": "La Fouly VS",
+        "city": "La Fouly",
         "zipcode": 1944,
         "canton": "VS"
     },
@@ -25040,7 +25135,7 @@
         "canton": "VS"
     },
     {
-        "city": "Le Ch\u00e2ble VS",
+        "city": "Le Ch\u00e2ble",
         "zipcode": 1934,
         "canton": "VS"
     },
@@ -25175,7 +25270,7 @@
         "canton": "VS"
     },
     {
-        "city": "M\u00fcnster VS",
+        "city": "M\u00fcnster",
         "zipcode": 3985,
         "canton": "VS"
     },
@@ -25185,7 +25280,7 @@
         "canton": "VS"
     },
     {
-        "city": "Biel VS",
+        "city": "Biel",
         "zipcode": 3989,
         "canton": "VS"
     },
@@ -25210,7 +25305,7 @@
         "canton": "VS"
     },
     {
-        "city": "Reckingen VS",
+        "city": "Reckingen",
         "zipcode": 3998,
         "canton": "VS"
     },
@@ -25300,7 +25395,7 @@
         "canton": "VS"
     },
     {
-        "city": "La Tour VS",
+        "city": "La Tour",
         "zipcode": 1984,
         "canton": "VS"
     },
@@ -25310,7 +25405,7 @@
         "canton": "VS"
     },
     {
-        "city": "La Forclaz VS",
+        "city": "La Forclaz",
         "zipcode": 1985,
         "canton": "VS"
     },
@@ -25335,7 +25430,7 @@
         "canton": "VS"
     },
     {
-        "city": "St-Martin VS",
+        "city": "St-Martin",
         "zipcode": 1969,
         "canton": "VS"
     },
@@ -25530,7 +25625,7 @@
         "canton": "VS"
     },
     {
-        "city": "Steg VS",
+        "city": "Steg",
         "zipcode": 3940,
         "canton": "VS"
     },
@@ -25662,6 +25757,11 @@
     {
         "city": "La Tzoumaz",
         "zipcode": 1918,
+        "canton": "VS"
+    },
+    {
+        "city": "Ovronnaz",
+        "zipcode": 1911,
         "canton": "VS"
     },
     {
@@ -25900,7 +26000,7 @@
         "canton": "VS"
     },
     {
-        "city": "Steg VS",
+        "city": "Steg",
         "zipcode": 3940,
         "canton": "VS"
     },
@@ -25945,7 +26045,7 @@
         "canton": "VS"
     },
     {
-        "city": "Unterb\u00e4ch VS",
+        "city": "Unterb\u00e4ch",
         "zipcode": 3944,
         "canton": "VS"
     },
@@ -25965,7 +26065,7 @@
         "canton": "VS"
     },
     {
-        "city": "Steg VS",
+        "city": "Steg",
         "zipcode": 3940,
         "canton": "VS"
     },
@@ -26015,7 +26115,7 @@
         "canton": "VS"
     },
     {
-        "city": "Le Ch\u00e2telard VS",
+        "city": "Le Ch\u00e2telard",
         "zipcode": 1925,
         "canton": "VS"
     },
@@ -26045,7 +26145,7 @@
         "canton": "VS"
     },
     {
-        "city": "Mex VS",
+        "city": "Mex",
         "zipcode": 1890,
         "canton": "VS"
     },
@@ -26140,7 +26240,7 @@
         "canton": "VS"
     },
     {
-        "city": "Crans VS",
+        "city": "Crans",
         "zipcode": 3963,
         "canton": "VS"
     },
@@ -26155,7 +26255,7 @@
         "canton": "VS"
     },
     {
-        "city": "Crans VS",
+        "city": "Crans",
         "zipcode": 3963,
         "canton": "VS"
     },
@@ -26165,7 +26265,7 @@
         "canton": "VS"
     },
     {
-        "city": "Ollon VS",
+        "city": "Ollon",
         "zipcode": 3971,
         "canton": "VS"
     },
@@ -26220,7 +26320,7 @@
         "canton": "VS"
     },
     {
-        "city": "Ollon VS",
+        "city": "Ollon",
         "zipcode": 3971,
         "canton": "VS"
     },
@@ -26235,7 +26335,7 @@
         "canton": "VS"
     },
     {
-        "city": "Granges VS",
+        "city": "Granges",
         "zipcode": 3977,
         "canton": "VS"
     },
@@ -26280,7 +26380,7 @@
         "canton": "VS"
     },
     {
-        "city": "St-Jean VS",
+        "city": "St-Jean",
         "zipcode": 3961,
         "canton": "VS"
     },
@@ -26330,7 +26430,7 @@
         "canton": "VS"
     },
     {
-        "city": "Ollon VS",
+        "city": "Ollon",
         "zipcode": 3971,
         "canton": "VS"
     },
@@ -26345,7 +26445,7 @@
         "canton": "VS"
     },
     {
-        "city": "Mollens VS",
+        "city": "Mollens",
         "zipcode": 3974,
         "canton": "VS"
     },
@@ -26605,7 +26705,7 @@
         "canton": "VS"
     },
     {
-        "city": "St. Niklaus VS",
+        "city": "St. Niklaus",
         "zipcode": 3924,
         "canton": "VS"
     },
@@ -26615,7 +26715,7 @@
         "canton": "VS"
     },
     {
-        "city": "Stalden VS",
+        "city": "Stalden",
         "zipcode": 3922,
         "canton": "VS"
     },
@@ -26660,7 +26760,7 @@
         "canton": "VS"
     },
     {
-        "city": "Stalden VS",
+        "city": "Stalden",
         "zipcode": 3922,
         "canton": "VS"
     },
@@ -26685,7 +26785,7 @@
         "canton": "VS"
     },
     {
-        "city": "Colombier NE",
+        "city": "Colombier",
         "zipcode": 2013,
         "canton": "NE"
     },
@@ -26745,7 +26845,7 @@
         "canton": "NE"
     },
     {
-        "city": "Corcelles NE",
+        "city": "Corcelles",
         "zipcode": 2035,
         "canton": "NE"
     },
@@ -26790,7 +26890,7 @@
         "canton": "NE"
     },
     {
-        "city": "Colombier NE",
+        "city": "Colombier",
         "zipcode": 2013,
         "canton": "NE"
     },
@@ -26805,7 +26905,7 @@
         "canton": "NE"
     },
     {
-        "city": "Corcelles NE",
+        "city": "Corcelles",
         "zipcode": 2035,
         "canton": "NE"
     },
@@ -26865,7 +26965,7 @@
         "canton": "NE"
     },
     {
-        "city": "La Sagne NE",
+        "city": "La Sagne",
         "zipcode": 2314,
         "canton": "NE"
     },
@@ -26875,7 +26975,7 @@
         "canton": "NE"
     },
     {
-        "city": "Renan BE",
+        "city": "Renan",
         "zipcode": 2616,
         "canton": "NE"
     },
@@ -26885,7 +26985,7 @@
         "canton": "NE"
     },
     {
-        "city": "La Sagne NE",
+        "city": "La Sagne",
         "zipcode": 2314,
         "canton": "NE"
     },
@@ -26980,7 +27080,7 @@
         "canton": "NE"
     },
     {
-        "city": "La Sagne NE",
+        "city": "La Sagne",
         "zipcode": 2314,
         "canton": "NE"
     },
@@ -27010,7 +27110,7 @@
         "canton": "NE"
     },
     {
-        "city": "Cornaux NE",
+        "city": "Cornaux",
         "zipcode": 2087,
         "canton": "NE"
     },
@@ -27020,12 +27120,12 @@
         "canton": "NE"
     },
     {
-        "city": "Cornaux NE",
+        "city": "Cornaux",
         "zipcode": 2087,
         "canton": "NE"
     },
     {
-        "city": "Cressier NE",
+        "city": "Cressier",
         "zipcode": 2088,
         "canton": "NE"
     },
@@ -27040,7 +27140,7 @@
         "canton": "NE"
     },
     {
-        "city": "Hauterive NE",
+        "city": "Hauterive",
         "zipcode": 2068,
         "canton": "NE"
     },
@@ -27080,7 +27180,7 @@
         "canton": "NE"
     },
     {
-        "city": "Corcelles NE",
+        "city": "Corcelles",
         "zipcode": 2035,
         "canton": "NE"
     },
@@ -27105,7 +27205,7 @@
         "canton": "NE"
     },
     {
-        "city": "Hauterive NE",
+        "city": "Hauterive",
         "zipcode": 2068,
         "canton": "NE"
     },
@@ -27155,7 +27255,7 @@
         "canton": "NE"
     },
     {
-        "city": "Fontaines NE",
+        "city": "Fontaines",
         "zipcode": 2046,
         "canton": "NE"
     },
@@ -27195,12 +27295,12 @@
         "canton": "NE"
     },
     {
-        "city": "Le P\u00e2quier NE",
+        "city": "Le P\u00e2quier",
         "zipcode": 2058,
         "canton": "NE"
     },
     {
-        "city": "Vilars NE",
+        "city": "Vilars",
         "zipcode": 2063,
         "canton": "NE"
     },
@@ -27245,7 +27345,7 @@
         "canton": "NE"
     },
     {
-        "city": "La Sagne NE",
+        "city": "La Sagne",
         "zipcode": 2314,
         "canton": "NE"
     },
@@ -27260,7 +27360,7 @@
         "canton": "NE"
     },
     {
-        "city": "Renan BE",
+        "city": "Renan",
         "zipcode": 2616,
         "canton": "NE"
     },
@@ -27300,7 +27400,7 @@
         "canton": "NE"
     },
     {
-        "city": "M\u00f4tiers NE",
+        "city": "M\u00f4tiers",
         "zipcode": 2112,
         "canton": "NE"
     },
@@ -27325,7 +27425,7 @@
         "canton": "NE"
     },
     {
-        "city": "St-Sulpice NE",
+        "city": "St-Sulpice",
         "zipcode": 2123,
         "canton": "NE"
     },
@@ -27420,7 +27520,7 @@
         "canton": "GE"
     },
     {
-        "city": "Carouge GE",
+        "city": "Carouge",
         "zipcode": 1227,
         "canton": "GE"
     },
@@ -27515,7 +27615,7 @@
         "canton": "GE"
     },
     {
-        "city": "Corsier GE",
+        "city": "Corsier",
         "zipcode": 1246,
         "canton": "GE"
     },
@@ -27585,7 +27685,7 @@
         "canton": "GE"
     },
     {
-        "city": "Carouge GE",
+        "city": "Carouge",
         "zipcode": 1227,
         "canton": "GE"
     },
@@ -27890,7 +27990,7 @@
         "canton": "JU"
     },
     {
-        "city": "Ch\u00e2tillon JU",
+        "city": "Ch\u00e2tillon",
         "zipcode": 2843,
         "canton": "JU"
     },
@@ -28035,6 +28135,11 @@
         "canton": "JU"
     },
     {
+        "city": "Roggenburg",
+        "zipcode": 2814,
+        "canton": "JU"
+    },
+    {
         "city": "Rossemaison",
         "zipcode": 2842,
         "canton": "JU"
@@ -28110,7 +28215,7 @@
         "canton": "JU"
     },
     {
-        "city": "Le B\u00e9mont JU",
+        "city": "Le B\u00e9mont",
         "zipcode": 2360,
         "canton": "JU"
     },
@@ -28155,7 +28260,7 @@
         "canton": "JU"
     },
     {
-        "city": "Les Genevez JU",
+        "city": "Les Genevez",
         "zipcode": 2714,
         "canton": "JU"
     },
@@ -28170,7 +28275,7 @@
         "canton": "JU"
     },
     {
-        "city": "Lajoux JU",
+        "city": "Lajoux",
         "zipcode": 2718,
         "canton": "JU"
     },
@@ -28190,7 +28295,7 @@
         "canton": "JU"
     },
     {
-        "city": "Lajoux JU",
+        "city": "Lajoux",
         "zipcode": 2718,
         "canton": "JU"
     },

--- a/tests/CitySearchTest.php
+++ b/tests/CitySearchTest.php
@@ -4,6 +4,8 @@ namespace Wnx\SwissCantons\Tests;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Wnx\SwissCantons\Canton;
+use Wnx\SwissCantons\Cantons;
 use Wnx\SwissCantons\CitySearch;
 
 class CitySearchTest extends TestCase
@@ -55,6 +57,27 @@ class CitySearchTest extends TestCase
         $result = $citySearch->findByZipcode(9494);
 
         $this->assertEmpty($result);
+    }
+
+    #[Test]
+    public function it_does_not_find_any_canton_at_the_end_of_city_name(): void
+    {
+        $cantonsAbbreviations = array_map(fn (Canton $canton) => $canton->getAbbreviation(), (new Cantons())->getAll());
+
+        $citySearch = new CitySearch();
+
+        $cities = $citySearch->getDataSet();
+
+        $this->assertNotEmpty($cities);
+
+        foreach ($cities as $city) {
+            $cityName = $city['city'];
+
+            if (preg_match('/ ([A-Z]{2})$/', $cityName, $matches)) {
+                $canton = $matches[1];
+                $this->assertNotContains($canton, $cantonsAbbreviations, "City '$cityName' ends with the canton '$canton'.");
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Many of cities from the `cities.json` end with a canton abbreviation, which is not always the same as the indicated city's canton.
Also, it improves the search by zipcode and city name.

This fix removes all potential canton abbreviation from cities names.